### PR TITLE
Client read write queue

### DIFF
--- a/blatann/event_args.py
+++ b/blatann/event_args.py
@@ -1,6 +1,24 @@
 from enum import Enum
 
 
+class GattOperationCompleteReason(Enum):
+    """
+    The reason why a GATT operation completed
+    """
+    # Operation successful
+    SUCCESS = 0
+    # Queue of queued operations (notifications,reads, writes) was leared
+    QUEUE_CLEARED = 1
+    # The client disconnected before the operation completed
+    CLIENT_DISCONNECTED = 2
+    # The server disconnected before the operation completed
+    SERVER_DISCONNECTED = 3
+    # The client unsubscribed from the characteristic before the notification was sent
+    CLIENT_UNSUBSCRIBED = 4
+    # Unknown Failure
+    FAILED = 4
+
+
 class EventArgs(object):
     """
     Base Event Arguments class
@@ -94,26 +112,14 @@ class NotificationCompleteEventArgs(EventArgs):
     """
     Event arguments for when a notification has been sent to the client from the notification queue
     """
-    class Reason(Enum):
-        """
-        The reason why the notification completed
-        """
-        # Sent Successfully
-        SUCCESS = 0
-        # Queue was requested to be cleared
-        QUEUE_CLEARED = 1
-        # The client disconnected before notification sent
-        CLIENT_DISCONNECTED = 2
-        # The client unsubscribed from the characteristic
-        CLIENT_UNSUBSCRIBED = 3
-        # Unknown Failure
-        FAILED = 4
+    Reason = GattOperationCompleteReason
 
     def __init__(self, notification_id, data, reason):
         """
         :param notification_id: The ID of the notification that completed. This will match an ID of a sent notification
         :param data: The data that was sent (or not sent, if failed) to the client
         :param reason: The reason the notification completed
+        :type reason: GattOperationCompleteReason
         """
         self.id = notification_id
         self.data = data
@@ -126,42 +132,57 @@ class ReadCompleteEventArgs(EventArgs):
     """
     Event arguments for when a read has completed of a peripheral's characteristic
     """
-    def __init__(self, value, status):
+    def __init__(self, read_id, value, status, reason):
         """
+        :param read_id: The ID of the read that completed. This will match an id of an initiated read
         :param value: The value read by the characteristic (bytes)
         :param status: The read status
         :type status: blatann.gatt.GattStatusCode
+        :param reason: The reason the read completed
+        :type reason: GattOperationCompleteReason
         """
+        self.id = read_id
         self.value = value
         self.status = status
+        self.reason = reason
 
 
 class WriteCompleteEventArgs(EventArgs):
     """
     Event arguments for when a write has completed on a peripheral's characteristic
     """
-    def __init__(self, value, status):
+    def __init__(self, write_id, value, status, reason):
         """
+        :param write_id: the ID of the write that completed. This will match an id of an initiated write
         :param value: The value that was written to the characteristic (bytes)
         :param status: The write status
         :type status: blatann.gatt.GattStatusCode
+        :param reason: The reason the write completed
+        :type reason: GattOperationCompleteReason
         """
+        self.id = write_id
         self.value = value
         self.status = status
+        self.reason = reason
 
 
 class SubscriptionWriteCompleteEventArgs(EventArgs):
     """
     Event arguments for when changing the subscription state of a characteristic completes
     """
-    def __init__(self, value, status):
+    def __init__(self, write_id, value, status, reason):
         """
+        :param write_id: the ID of the write that completed. This will match an id of an initiated write
         :param value: The value that was written to the characteristic (bytes)
         :param status: The write status
         :type status: blatann.gatt.GattStatusCode
+        :param reason: The reason the write completed
+        :type reason: GattOperationCompleteReason
         """
+        self.id = write_id
         self.value = value
         self.status = status
+        self.reason = reason
 
 
 class NotificationReceivedEventArgs(EventArgs):

--- a/blatann/gatt/gattc.py
+++ b/blatann/gatt/gattc.py
@@ -40,6 +40,8 @@ class GattcCharacteristic(gatt.Characteristic):
         self._on_cccd_write_complete_event = EventSource("CCCD Write Complete", logger)
 
         self.peer.driver_event_subscribe(self._on_indication_notification, nrf_events.GattcEvtHvx)
+        self._manager.on_write_complete.register(self._write_complete)
+        self._manager.on_read_complete.register(self._read_complete)
 
     """
     Properties
@@ -183,7 +185,7 @@ class GattcCharacteristic(gatt.Characteristic):
 
     def _read_complete(self, sender, event_args):
         """
-        Handler for GattcReader.on_read_complete.
+        Handler for _ReadWriteManager.on_read_complete.
         Dispatches the on_read_complete event and updates the internal value if read was successful
 
         :param sender: The reader that the read completed on
@@ -199,7 +201,7 @@ class GattcCharacteristic(gatt.Characteristic):
 
     def _write_complete(self, sender, event_args):
         """
-        Handler for GattcWriter.on_write_complete. Dispatches on_write_complete or on_cccd_write_complete
+        Handler for _ReadWriteManager.on_write_complete. Dispatches on_write_complete or on_cccd_write_complete
         depending on the handle the write finished on.
 
         :param sender: The writer that the write completed on
@@ -409,6 +411,8 @@ class _ReadWriteManager(QueuedTasksManagerBase):
         self._cur_write_task = None
         self.on_read_complete = EventSource("Gattc Read Complete", logger)
         self.on_write_complete = EventSource("Gattc Write Complete", logger)
+        self._reader.on_read_complete.register(self._read_complete)
+        self._writer.on_write_complete.register(self._write_complete)
 
     def read(self, handle):
         read_task = _ReadTask(handle)

--- a/blatann/gatt/reader.py
+++ b/blatann/gatt/reader.py
@@ -53,7 +53,8 @@ class GattcReader(object):
         read is in progress, raises an InvalidStateException
 
         :param handle: the attribute handle to read
-        :return: A waitable that will fire when the read finishes. See on_read_complete for the values returned from the waitable
+        :return: A waitable that will fire when the read finishes.
+                 See on_read_complete for the values returned from the waitable
         :rtype: EventWaitable
         """
         if self._busy:
@@ -92,4 +93,5 @@ class GattcReader(object):
 
     def _complete(self, status=nrf_events.BLEGattStatusCode.success):
         self._busy = False
-        self._on_read_complete_event.notify(self, GattcReadCompleteEventArgs(self._handle, status, bytes(self._data)))
+        event_args = GattcReadCompleteEventArgs(self._handle, status, bytes(self._data))
+        self._on_read_complete_event.notify(self, event_args)

--- a/blatann/gatt/writer.py
+++ b/blatann/gatt/writer.py
@@ -94,7 +94,7 @@ class GattcWriter(object):
 
     def _on_write_response(self, driver, event):
         """
-        Handler fro GattcEvtWriteResponse
+        Handler for GattcEvtWriteResponse
 
         :type event: nrf_events.GattcEvtWriteResponse
         """

--- a/blatann/services/glucose/service.py
+++ b/blatann/services/glucose/service.py
@@ -50,10 +50,10 @@ class GlucoseServer(object):
         if self._current_command:
             if len(self._records_to_report) > 0:
                 next_record = self._records_to_report.pop(0)
-                noti_id = self.measurement_characteristic.notify(next_record.encode().value).notification_id
+                noti_id = self.measurement_characteristic.notify(next_record.encode().value).id
                 self._active_notifications.append(noti_id)
-                if next_record.context:
-                    noti_id = self.context_characteristic.notify(next_record.context.encode().value).notification_id
+                if next_record.context and self.context_characteristic.client_subscribed:
+                    noti_id = self.context_characteristic.notify(next_record.context.encode().value).id
                     self._active_notifications.append(noti_id)
             else:
                 # Done reporting

--- a/blatann/utils/queued_tasks_manager.py
+++ b/blatann/utils/queued_tasks_manager.py
@@ -1,0 +1,70 @@
+import threading
+import queue
+import logging
+
+
+logger = logging.getLogger(__name__)
+
+
+class QueuedTasksManagerBase(object):
+    """
+    Handles queuing of tasks that can only be done one at a time
+    """
+    def __init__(self):
+        self._queue = queue.Queue()
+        self._in_process = threading.Event()
+        self._lock = threading.RLock()
+
+    def _add_task(self, task):
+        with self._lock:
+            if self._in_process.is_set():
+                self._queue.put(task)
+            else:
+                try:
+                    task_complete = self._handle_task(task)
+                    if not task_complete:
+                        self._in_process.set()
+                except Exception as e:
+                    self._handle_task_failure(task, e)
+
+    def _task_completed(self, task):
+        with self._lock:
+            task = self._get_next()
+            while task:
+                try:
+                    task_complete = self._handle_task(task)
+                    if not task_complete:
+                        break
+                except Exception as e:
+                    logger.exception(e)
+                    self._handle_task_failure(task, e)
+
+            if not task:
+                self._in_process.clear()
+
+    def _get_next(self):
+        try:
+            return self._queue.get_nowait()
+        except queue.Empty:
+            return None
+
+    def _clear_all(self, reason):
+        with self._lock:
+            task = self._get_next()
+            while task:
+                self._handle_task_cleared(task, reason)
+                task = self._get_next()
+            self._in_process.clear()
+
+    def clear_all(self):
+        raise NotImplementedError()
+
+    def _handle_task(self, task):
+        raise NotImplementedError()
+
+    def _handle_task_failure(self, task, e):
+        raise NotImplementedError()
+
+    def _handle_task_cleared(self, task, reason):
+        raise NotImplementedError()
+

--- a/blatann/waitables/event_waitable.py
+++ b/blatann/waitables/event_waitable.py
@@ -24,11 +24,11 @@ class EventWaitable(Waitable):
         return res
 
 
-class NotificationCompleteEventWaitable(EventWaitable):
-    def __init__(self, event, notification_id):
-        super(NotificationCompleteEventWaitable, self).__init__(event)
-        self.notification_id = notification_id
+class IdBasedEventWaitable(EventWaitable):
+    def __init__(self, event, event_id):
+        super(IdBasedEventWaitable, self).__init__(event)
+        self.id = event_id
 
-    def _on_event(self, characteristic, event_args):
-        if event_args.id == self.notification_id:
-            super(NotificationCompleteEventWaitable, self)._on_event(characteristic, event_args)
+    def _on_event(self, sender, event_args):
+        if event_args.id == self.id:
+            super(IdBasedEventWaitable, self)._on_event(sender, event_args)


### PR DESCRIPTION
Adds queue to facilitate reads/writes with a client connection, since only one GATTC operation can be active at a time