### PR TITLE
Fix handling of timedelta in current time service

### DIFF
--- a/blatann/services/current_time/service.py
+++ b/blatann/services/current_time/service.py
@@ -159,7 +159,7 @@ class CurrentTimeServer(object):
             self._time_delta = datetime.timedelta()
         else:
             delta = date - datetime.datetime.now()
-            if delta.total_seconds() < 1:  #
+            if abs(delta.total_seconds()) < 1:
                 delta = datetime.timedelta()
             self._time_delta = delta
         if characteristic_read_callback:


### PR DESCRIPTION
Explicit check of total_seconds < 1 was preventing dates in the
past from being set