### PR TITLE
Fixes bug where driver event handlers may not be called if unsub happened during event handling

### DIFF
--- a/blatann/nrf/nrf_driver.py
+++ b/blatann/nrf/nrf_driver.py
@@ -631,8 +631,6 @@ class NrfDriver(object):
             except queue.Empty:
                 continue
 
-            # logger.info('ble_event.header.evt_id %r', ble_event.header.evt_id)
-
             if len(self.observers) == 0:
                 continue
 
@@ -641,12 +639,10 @@ class NrfDriver(object):
                 logger.warning('unknown ble_event %r (discarded)', ble_event.header.evt_id)
                 continue
 
-            # logger.debug('ble_event.header.evt_id %r ----  %r', ble_event.header.evt_id, event)
-
             # Get a copy of the observers and event observers in case its modified during this execution
             with self._event_observer_lock:
                 observers = self.observers[:]
-                event_handlers = {e: h[:] for e, h in self._event_observers.items()}
+                event_handlers = {k: v[:] for k, v in self._event_observers.items()}
 
             # Call all the observers
             for obs in observers:

--- a/blatann/nrf/nrf_driver.py
+++ b/blatann/nrf/nrf_driver.py
@@ -646,7 +646,7 @@ class NrfDriver(object):
             # Get a copy of the observers and event observers in case its modified during this execution
             with self._event_observer_lock:
                 observers = self.observers[:]
-                event_handlers = self._event_observers.copy()
+                event_handlers = {e: h[:] for e, h in self._event_observers.items()}
 
             # Call all the observers
             for obs in observers:


### PR DESCRIPTION
The event handlers dictionary was getting shallow-copied when processing an event, such that the handler list attached to each key could be modified when iterating over the handler list. This causes issues when a handler unregisters itself when processing the event, thus modifying the list as it's being iterated and causing the next handler to be skipped.

This changes it such that the handler list for each dict entry is copied as well
