### PR TITLE
Advertising data testing

### DIFF
--- a/blatann/gap/advertise_data.py
+++ b/blatann/gap/advertise_data.py
@@ -1,3 +1,4 @@
+import time
 from typing import Iterable, List
 import logging
 from blatann.nrf import nrf_types
@@ -192,6 +193,7 @@ class ScanReport(object):
         """
         :type adv_report: blatann.nrf.nrf_events.GapEvtAdvReport
         """
+        self.timestamp = time.time()
         self.peer_address = adv_report.peer_addr
         self._current_advertise_data = adv_report.adv_data.records.copy()
         self.advertise_data = AdvertisingData.from_ble_adv_records(self._current_advertise_data)
@@ -208,6 +210,7 @@ class ScanReport(object):
         """
         if adv_report.peer_addr != self.peer_address:
             raise exceptions.InvalidOperationException("Peer address doesn't match")
+
         self._current_advertise_data.update(adv_report.adv_data.records)
         self.advertise_data = AdvertisingData.from_ble_adv_records(self._current_advertise_data.copy())
         self.rssi = max(self.rssi, adv_report.rssi)

--- a/blatann/gap/advertise_data.py
+++ b/blatann/gap/advertise_data.py
@@ -1,5 +1,5 @@
 import time
-from typing import Iterable, List
+from typing import Iterable, List, Dict, Union
 import logging
 from blatann.nrf import nrf_types
 from blatann import uuid, exceptions
@@ -16,6 +16,9 @@ class AdvertisingFlags(object):
     BR_EDR_HOST = 0x10
 
 
+AdvertisingPacketType = nrf_types.BLEGapAdvType
+
+
 class AdvertisingData(object):
     """
     Class which represents data that can be advertised
@@ -27,21 +30,71 @@ class AdvertisingData(object):
     def __init__(self, flags=None, local_name=None, local_name_complete=True,
                  service_uuid16s=None, service_uuid128s=None,
                  has_more_uuid16_services=False, has_more_uuid128_services=False,
-                 service_data=None, manufacturer_data=None, **other_flags):
-        self.flags = flags
+                 service_data=None, manufacturer_data=None, **other_entries):
+        self.entries = {self.Types[k]: v for k, v in other_entries.items()}
+        if flags is not None:
+            self.entries[self.Types.flags] = flags
+        if service_data:
+            self.entries[self.Types.service_data] = service_data
+        if manufacturer_data:
+            self.entries[self.Types.manufacturer_specific_data] = manufacturer_data
+
         self.local_name = local_name
         self.local_name_complete = local_name_complete
         self.service_uuid16s = service_uuid16s or []
         self.service_uuid128s = service_uuid128s or []
         self.has_more_uuid16_services = has_more_uuid16_services
         self.has_more_uuid128_services = has_more_uuid128_services
-        self.service_data = service_data
-        self.manufacturer_data = manufacturer_data
-        self.other_flags = {self.Types[k]: v for k, v in other_flags.items()}
         if not isinstance(self.service_uuid16s, (list, tuple)):
             self.service_uuid16s = [self.service_uuid16s]
         if not isinstance(self.service_uuid128s, (list, tuple)):
             self.service_uuid128s = [self.service_uuid128s]
+
+    def _get(self, t, default=None):
+        return self.entries.get(t, default)
+
+    def _set(self, t, value):
+        self.entries[t] = value
+
+    def _del(self, t):
+        if t in self.entries:
+            del self.entries[t]
+
+    @property
+    def flags(self) -> int:
+        return self._get(self.Types.flags)
+
+    @flags.setter
+    def flags(self, value: int):
+        self._set(self.Types.flags, value)
+
+    @flags.deleter
+    def flags(self):
+        self._del(self.Types.flags)
+
+    @property
+    def service_data(self) -> Union[bytes, List[int]]:
+        return self._get(self.Types.service_data, None)
+
+    @service_data.setter
+    def service_data(self, value: Union[bytes, List[int]]):
+        self._set(self.Types.service_data, value)
+
+    @service_data.deleter
+    def service_data(self):
+        self._del(self.Types.service_data)
+
+    @property
+    def manufacturer_data(self) -> Union[bytes, List[int]]:
+        return self._get(self.Types.manufacturer_specific_data, None)
+
+    @manufacturer_data.setter
+    def manufacturer_data(self, value: Union[bytes, List[int]]):
+        self._set(self.Types.manufacturer_specific_data, value)
+
+    @manufacturer_data.deleter
+    def manufacturer_data(self):
+        self._del(self.Types.manufacturer_specific_data)
 
     @property
     def service_uuids(self):
@@ -72,33 +125,31 @@ class AdvertisingData(object):
         :return: the BLEAdvData object which represents this advertising data
         :rtype: nrf_types.BLEAdvData
         """
-        records = self.other_flags.copy()
-        if self.flags:
-            records[self.Types.flags] = [int(self.flags)]
-        if self.local_name:
-            name_type = self.Types.complete_local_name if self.local_name_complete else self.Types.short_local_name
-            records[name_type] = self.local_name
+        records = self.entries.copy()
+
         if self.service_uuid128s:
-            uuid_type = self.Types.service_128bit_uuid_more_available if self.has_more_uuid128_services else self.Types.service_128bit_uuid_complete
-            # UUID data is little-endian, reverse the lists and concatenate
-            uuid_data = []
-            for u in self.service_uuid128s:
-                uuid_data.extend(u.uuid[::-1])
-            records[uuid_type] = uuid_data
+            t = self.Types.service_128bit_uuid_more_available if self.has_more_uuid128_services else self.Types.service_128bit_uuid_complete
+            data = [b for u in self.service_uuid128s for b in u.uuid[::-1]]
+            records[t] = data
         if self.service_uuid16s:
-            uuid_type = self.Types.service_16bit_uuid_more_available if self.has_more_uuid16_services else self.Types.service_16bit_uuid_complete
-            uuid_data = []
-            for u in self.service_uuid16s:
-                uuid_data.append(u.uuid & 0xFF)
-                uuid_data.append((u.uuid >> 8) & 0xFF)
-            records[uuid_type] = uuid_data
-        if self.service_data:
-            records[self.Types.service_data] = self.service_data
-        if self.manufacturer_data:
-            records[self.Types.manufacturer_specific_data] = self.manufacturer_data
+            t = self.Types.service_16bit_uuid_more_available if self.has_more_uuid16_services else self.Types.service_16bit_uuid_complete
+            data = [b for u in self.service_uuid16s for b in [u.uuid & 0xFF, u.uuid >> 8 & 0xFF]]
+            records[t] = data
+        if self.local_name:
+            t = self.Types.complete_local_name if self.local_name_complete else self.Types.short_local_name
+            records[t] = self.local_name
+
+        for k, v in records.items():
+            if isinstance(v, int):
+                records[k] = [v]
 
         record_string_keys = {k.name: v for k, v in records.items()}
         return nrf_types.BLEAdvData(**record_string_keys)
+
+    def to_bytes(self):
+        adv_data = self.to_ble_adv_data()
+        adv_data.to_list()
+        return adv_data.raw_bytes
 
     @classmethod
     def from_ble_adv_records(cls, advertise_records):
@@ -157,7 +208,7 @@ class AdvertisingData(object):
                 uuid128 = uuid128_data[i:i+16][::-1]
                 service_uuid128s.append(uuid.Uuid128(uuid128))
 
-        record_string_keys = {k.name: bytearray(v) for k, v in advertise_records.items()}
+        record_string_keys = {k.name: bytes(v) for k, v in advertise_records.items()}
         return AdvertisingData(flags=flags, local_name=local_name, local_name_complete=local_name_complete,
                                service_uuid16s=service_uuid16s, service_uuid128s=service_uuid128s,
                                has_more_uuid16_services=more_16bit_services, has_more_uuid128_services=more_128bit_services,
@@ -187,6 +238,14 @@ class AdvertisingData(object):
 
         return "{}({})".format(self.__class__.__name__, ", ".join(params))
 
+    def __eq__(self, other):
+        if not isinstance(other, AdvertisingData):
+            return False
+        return (self.entries == other.entries and
+                self.local_name == other.local_name and
+                self.service_uuid16s == other.service_uuid16s and
+                self.service_uuid128s == other.service_uuid128s)
+
 
 class ScanReport(object):
     def __init__(self, adv_report):
@@ -195,10 +254,12 @@ class ScanReport(object):
         """
         self.timestamp = time.time()
         self.peer_address = adv_report.peer_addr
+        self.packet_type: AdvertisingPacketType = adv_report.adv_type
         self._current_advertise_data = adv_report.adv_data.records.copy()
         self.advertise_data = AdvertisingData.from_ble_adv_records(self._current_advertise_data)
         self.rssi = adv_report.rssi
         self.duplicate = False
+        self.raw_bytes = adv_report.adv_data.raw_bytes
 
     @property
     def device_name(self):
@@ -211,12 +272,15 @@ class ScanReport(object):
         if adv_report.peer_addr != self.peer_address:
             raise exceptions.InvalidOperationException("Peer address doesn't match")
 
-        self._current_advertise_data.update(adv_report.adv_data.records)
+        self._current_advertise_data.update(adv_report.adv_data.records.copy())
         self.advertise_data = AdvertisingData.from_ble_adv_records(self._current_advertise_data.copy())
         self.rssi = max(self.rssi, adv_report.rssi)
+        self.raw_bytes = b""
 
     def __eq__(self, other):
-        return self.peer_address == other.peer_address and self._current_advertise_data == other._current_advertise_data
+        if not isinstance(other, ScanReport):
+            return False
+        return self.peer_address == other.peer_address and self.advertise_data == other.advertise_data
 
     def __repr__(self):
         return "{}: {}dBm - {}".format(self.device_name, self.rssi, self.advertise_data)
@@ -233,7 +297,10 @@ class ScanReportCollection(object):
     @property
     def advertising_peers_found(self) -> Iterable[ScanReport]:
         """
-        Gets the list of scans which have been combined and condensed into a list where each entry is a unique peer
+        Gets the list of scans which have been combined and condensed into a list where each entry is a unique peer.
+        The scan reports in this list represent aggregated data of each advertising packet received by the advertising
+        device, such that later advertising packets will update/overwrite packet attributes received
+        from earlier packets, if the data has been modified.
 
         :return: The list of scan reports, with each being a unique peer
         :rtype: list of ScanReport
@@ -248,7 +315,7 @@ class ScanReportCollection(object):
         :return: The list of all scan reports
         :rtype: list of ScanReport
         """
-        return self._all_scans
+        return self._all_scans[:]
 
     def clear(self):
         """
@@ -268,5 +335,5 @@ class ScanReportCollection(object):
         if adv_report.peer_addr in self._scans_by_peer_address.keys():
             self._scans_by_peer_address[adv_report.peer_addr].update(adv_report)
         else:
-            self._scans_by_peer_address[adv_report.peer_addr] = scan_entry
+            self._scans_by_peer_address[adv_report.peer_addr] = ScanReport(adv_report)
         return self._scans_by_peer_address[adv_report.peer_addr]

--- a/blatann/gap/scanning.py
+++ b/blatann/gap/scanning.py
@@ -42,7 +42,7 @@ class Scanner(object):
         """
         return self._on_scan_timeout
 
-    def set_default_scan_params(self, interval_ms=200, window_ms=150, timeout_seconds=10):
+    def set_default_scan_params(self, interval_ms=200, window_ms=150, timeout_seconds=10, active_scanning=True):
         """
         Sets the default scan parameters so they do not have to be specified each time a scan is started.
         Reference the Bluetooth specification for valid ranges for parameters.
@@ -51,10 +51,12 @@ class Scanner(object):
         :param window_ms: How long within a single scan interval to be actively listening for advertising packets,
                           in milliseconds
         :param timeout_seconds: How long to advertise for, in seconds
+        :param active_scanning: Whether or not to fetch scan response packets from advertisers
         """
         self._default_scan_params.interval_ms = interval_ms
         self._default_scan_params.window_ms = window_ms
         self._default_scan_params.timeout_s = timeout_seconds
+        self._default_scan_params.active = active_scanning
 
     def start_scan(self, scan_parameters=None, clear_scan_reports=True):
         """
@@ -80,8 +82,6 @@ class Scanner(object):
         """
         Stops an active scan
         """
-        if not self.scanning:
-            return
         self.scanning = False
 
         try:

--- a/blatann/nrf/nrf_driver.py
+++ b/blatann/nrf/nrf_driver.py
@@ -61,7 +61,7 @@ def NordicSemiErrorCheck(wrapped=None, expected=driver.NRF_SUCCESS):
 
     @wrapt.decorator
     def wrapper(wrapped, instance, args, kwargs):
-        logger.debug("{}{}".format(wrapped.__name__, args))
+        logger.debug("[{}] {}{}".format(instance.serial_port, wrapped.__name__, args))
         result = wrapped(*args, **kwargs)
         if isinstance(result, (list, tuple)):
             err_code = result[0]
@@ -115,6 +115,10 @@ class NrfDriver(object):
         link_layer = driver.sd_rpc_data_link_layer_create_bt_three_wire(phy_layer, 100)
         transport_layer = driver.sd_rpc_transport_layer_create(link_layer, 100)
         self.rpc_adapter = driver.sd_rpc_adapter_create(transport_layer)
+
+    @property
+    def serial_port(self):
+        return self._serial_port
 
     @NordicSemiErrorCheck
     @wrapt.synchronized(api_lock)

--- a/blatann/nrf/nrf_types/gap.py
+++ b/blatann/nrf/nrf_types/gap.py
@@ -35,16 +35,16 @@ class BLEGapAdvParams(object):
 
 
 class BLEGapScanParams(object):
-    def __init__(self, interval_ms, window_ms, timeout_s):
+    def __init__(self, interval_ms, window_ms, timeout_s, active=True):
         self.interval_ms = interval_ms
         self.window_ms = window_ms
         self.timeout_s = timeout_s
+        self.active = active
 
     def to_c(self):
         scan_params = driver.ble_gap_scan_params_t()
-        scan_params.active = True
-        scan_params.selective = False
-        scan_params.p_whitelist = None
+        scan_params.active = self.active
+        scan_params.use_whitelist = False
         scan_params.interval = util.msec_to_units(self.interval_ms,
                                                   util.UNIT_0_625_MS)
         scan_params.window = util.msec_to_units(self.window_ms,

--- a/blatann/nrf/nrf_types/gap.py
+++ b/blatann/nrf/nrf_types/gap.py
@@ -217,6 +217,7 @@ class BLEAdvData(object):
         self.records = dict()
         for k in kwargs:
             self.records[BLEAdvData.Types[k]] = kwargs[k]
+        self.raw_bytes = b""
 
     def to_list(self):
         data_list = []
@@ -231,6 +232,7 @@ class BLEAdvData(object):
 
             else:
                 raise NordicSemiException('Unsupported value type: 0x{:02X}'.format(type(self.records[k])))
+        self.raw_bytes = bytes(data_list)
         return data_list
 
     def to_c(self):
@@ -246,6 +248,7 @@ class BLEAdvData(object):
     def from_c(cls, adv_report_evt):
         ad_list = util.uint8_array_to_list(adv_report_evt.data, adv_report_evt.dlen)
         ble_adv_data = cls()
+        ble_adv_data.raw_bytes = bytes(ad_list)
         index = 0
         while index < len(ad_list):
             ad_len = ad_list[index]

--- a/blatann/utils/__init__.py
+++ b/blatann/utils/__init__.py
@@ -21,6 +21,7 @@ class Stopwatch(object):
     def __init__(self):
         self._t_start = 0
         self._t_stop = 0
+        self._t_mark = 0
         self._is_running = False
 
     def start(self):
@@ -32,6 +33,14 @@ class Stopwatch(object):
         if self._is_running:
             self._t_stop = time.time_ns()
             self._is_running = False
+
+    def mark(self):
+        if self._is_running:
+            self._t_mark = time.time_ns()
+
+    @property
+    def is_running(self):
+        return self._is_running
 
     @property
     def start_time(self):
@@ -58,7 +67,9 @@ class Stopwatch(object):
         if self._t_start == 0:
             raise RuntimeError("Timer was never started")
         if self._is_running:
-            return time.time_ns() - self._t_start
+            if self._t_mark == 0:
+                return time.time_ns() - self._t_start
+            return self._t_mark - self._t_start
         return self._t_stop - self._t_start
 
     def __enter__(self):

--- a/blatann/utils/__init__.py
+++ b/blatann/utils/__init__.py
@@ -23,20 +23,22 @@ class Stopwatch(object):
         self._t_stop = 0
         self._t_mark = 0
         self._is_running = False
+        self._started = False
 
     def start(self):
-        self._t_start = time.time_ns()
+        self._t_start = time.perf_counter()
         self._t_stop = 0
+        self._started = True
         self._is_running = True
 
     def stop(self):
         if self._is_running:
-            self._t_stop = time.time_ns()
+            self._t_stop = time.perf_counter()
             self._is_running = False
 
     def mark(self):
         if self._is_running:
-            self._t_mark = time.time_ns()
+            self._t_mark = time.perf_counter()
 
     @property
     def is_running(self):
@@ -52,23 +54,11 @@ class Stopwatch(object):
 
     @property
     def elapsed(self):
-        return self.elapsed_ns / 1.0E9
-
-    @property
-    def elapsed_ms(self):
-        return self.elapsed_ns / 1.0E6
-
-    @property
-    def elapsed_us(self):
-        return self.elapsed_ns / 1.0E3
-
-    @property
-    def elapsed_ns(self):
-        if self._t_start == 0:
+        if not self._started:
             raise RuntimeError("Timer was never started")
         if self._is_running:
             if self._t_mark == 0:
-                return time.time_ns() - self._t_start
+                return time.perf_counter() - self._t_start
             return self._t_mark - self._t_start
         return self._t_stop - self._t_start
 

--- a/tests/integrated/.gitignore
+++ b/tests/integrated/.gitignore
@@ -1,2 +1,2 @@
 # Bonding database used for integrated tests
-bond_db.pkl
+bond_db*.pkl

--- a/tests/integrated/base.py
+++ b/tests/integrated/base.py
@@ -1,6 +1,8 @@
 import os
 import logging
-from unittest import TestCase
+from typing import Optional
+from unittest import TestCase, SkipTest
+
 from blatann import BleDevice
 from blatann.gap.default_bond_db import DefaultBondDatabaseLoader
 from blatann.utils import setup_logger
@@ -8,33 +10,61 @@ from blatann.utils import setup_logger
 HERE = os.path.dirname(__file__)
 
 BLATANN_QUICK_ENVKEY = "BLATANN_TEST_QUICK"
-BLATANN_DEV1_ENVKEY = "BLATANN_DEV_1"
-BLATANN_DEV2_ENVKEY = "BLATANN_DEV_2"
-BLATANN_DEV3_ENVKEY = "BLATANN_DEV_3"
+BLATANN_DEV_ENVKEY_FORMAT = "BLATANN_DEV_{}"
+BOND_DB_FILE_FMT = os.path.join(HERE, "bond_db{}.pkl")
+
+
+def _configure_device(dev_number, config, optional=False):
+    env_key = BLATANN_DEV_ENVKEY_FORMAT.format(dev_number)
+    comport = os.environ.get(env_key, None)
+    if not comport:
+        if optional:
+            return None
+        raise EnvironmentError(f"Environment variable {env_key} must be defined with the device's comport")
+    dev = BleDevice(comport)
+    dev.bond_db_loader = DefaultBondDatabaseLoader(BOND_DB_FILE_FMT.format(dev_number))
+    dev.configure(**config)
+    return dev
 
 
 class BlatannTestCase(TestCase):
     dev1: BleDevice
     dev2: BleDevice
+    dev3: Optional[BleDevice]
     logger: logging.Logger = None
-    bond_db_file = os.path.join(HERE, "bond_db.pkl")
+    bond_db_file_fmt = os.path.join(HERE, "bond_db{}.pkl")
+
+    requires_3_devices = False
+    dev1_config = {}
+    dev2_config = {}
+    dev3_config = {}
 
     @classmethod
     def setUpClass(cls) -> None:
         if BlatannTestCase.logger is None:
             BlatannTestCase.logger = setup_logger()
-        cls.dev1: BleDevice = BleDevice(os.environ[BLATANN_DEV1_ENVKEY])
-        cls.dev1.bond_db_loader = DefaultBondDatabaseLoader(cls.bond_db_file)
-        # cls.dev2: BleDevice = BleDevice(os.environ[BLATANN_DEV2_ENVKEY])
-        # cls.dev2.bond_db_loader = DefaultBondDatabaseLoader(cls.bond_db_file)
+
+        cls.dev1 = _configure_device(1, cls.dev1_config)
+        cls.dev2 = _configure_device(2, cls.dev2_config)
+
+        if cls.requires_3_devices:
+            cls.dev3 = _configure_device(3, cls.dev3_config)
+            if not cls.dev3:
+                raise SkipTest("Need third device for this TestCase")
+        else:
+            cls.dev3 = None
 
         cls.dev1.open(True)
-        # cls.dev2.open(True)
+        cls.dev2.open(True)
+        if cls.dev3:
+            cls.dev3.open(True)
 
     @classmethod
     def tearDownClass(cls) -> None:
         cls.dev1.close()
-        # cls.dev2.close()
+        cls.dev2.close()
+        if cls.dev3:
+            cls.dev3.close()
 
 
 class TestParams(object):

--- a/tests/integrated/base.py
+++ b/tests/integrated/base.py
@@ -5,6 +5,7 @@ from unittest import TestCase, SkipTest
 
 from blatann import BleDevice
 from blatann.gap.default_bond_db import DefaultBondDatabaseLoader
+from blatann.nrf import nrf_events
 from blatann.utils import setup_logger
 
 HERE = os.path.dirname(__file__)
@@ -24,6 +25,7 @@ def _configure_device(dev_number, config, optional=False):
     dev = BleDevice(comport)
     dev.bond_db_loader = DefaultBondDatabaseLoader(BOND_DB_FILE_FMT.format(dev_number))
     dev.configure(**config)
+    dev.event_logger.suppress(nrf_events.GapEvtAdvReport)
     return dev
 
 

--- a/tests/integrated/base.py
+++ b/tests/integrated/base.py
@@ -2,6 +2,7 @@ import os
 import logging
 from typing import Optional
 from unittest import TestCase, SkipTest
+from functools import wraps
 
 from blatann import BleDevice
 from blatann.gap.default_bond_db import DefaultBondDatabaseLoader
@@ -76,6 +77,7 @@ class TestParams(object):
         self._teardown = teardown
 
     def __call__(self, func):
+        @wraps(func)
         def subtest_runner(test_case: BlatannTestCase):
             try:
                 self.setup(test_case)
@@ -109,6 +111,7 @@ class TestParams(object):
 
 
 def long_running(func):
+    @wraps(func)
     def f(self: TestCase, *args, **kwargs):
         quick_tests = int(os.environ.get(BLATANN_QUICK_ENVKEY, 0))
         if quick_tests:

--- a/tests/integrated/test_advertising.py
+++ b/tests/integrated/test_advertising.py
@@ -3,6 +3,7 @@ import unittest
 
 from blatann.gap.advertise_data import AdvertisingData, AdvertisingFlags
 from blatann.gap.advertising import AdvertisingMode
+from blatann.gap.scanning import ScanReport, Scanner
 from blatann.utils import Stopwatch
 from blatann.event_type import event_subscriber
 
@@ -12,7 +13,7 @@ from tests.integrated.base import BlatannTestCase, TestParams, long_running
 class TestAdvertising(BlatannTestCase):
     def setUp(self) -> None:
         self.adv_interval_ms = 250
-        self.adv_duration = 2
+        self.adv_duration = 5
         self.adv_mode = AdvertisingMode.non_connectable_undirected
         self.adv_data = AdvertisingData(flags=0x06, local_name="Blatann Test")
 
@@ -21,20 +22,39 @@ class TestAdvertising(BlatannTestCase):
 
     def tearDown(self) -> None:
         self.dev1.advertiser.stop()
+        self.dev2.scanner.stop()
 
     @long_running
     @TestParams([dict(duration=x) for x in [1, 4, 8, 10, 15, 22, 30, 60]])
     def test_advertise_duration(self, duration):
         acceptable_delta = 0.100
+        scan_stopwatch = Stopwatch()
+        dev1_addr = self.dev1.address
 
-        with Stopwatch() as stopwatch:
-            w = self.dev1.advertiser.start(timeout_sec=duration)
-            w.wait(duration + 2)
+        def on_scan_report(scanner: Scanner, report: ScanReport):
+            if report.peer_address != dev1_addr:
+                return
+            if scan_stopwatch.is_running:
+                scan_stopwatch.mark()
+            else:
+                scan_stopwatch.start()
+
+        self.dev2.scanner.set_default_scan_params(50, 50, duration+2)
+
+        with event_subscriber(self.dev2.scanner.on_scan_received, on_scan_report):
+            self.dev2.scanner.start_scan()
+            with Stopwatch() as stopwatch:
+                w = self.dev1.advertiser.start(timeout_sec=duration)
+                w.wait(duration + 2)
+            self.dev2.scanner.stop()
 
         self.assertFalse(self.dev1.advertiser.is_advertising)
 
-        actual_delta = abs(duration - stopwatch.elapsed)
-        self.assertLessEqual(actual_delta, acceptable_delta)
+        wait_delta = abs(duration - stopwatch.elapsed)
+        self.assertLessEqual(wait_delta, acceptable_delta)
+
+        scan_delta = abs(duration - scan_stopwatch.elapsed)
+        self.assertLessEqual(scan_delta, acceptable_delta)
 
     @TestParams([dict(duration=x) for x in [1, 2, 4]])
     def test_advertise_duration_timeout_event(self, duration):
@@ -54,6 +74,11 @@ class TestAdvertising(BlatannTestCase):
 
         actual_delta = abs(duration - stopwatch.elapsed)
         self.assertLessEqual(actual_delta, acceptable_delta)
+
+    @TestParams([dict(interval_ms=x) for x in [50, 100, 200]])
+    def test_advertising_interval(self, interval_ms):
+        self.dev2.scanner.set_default_scan_params(50, 50, self.adv_duration + 2)
+
 
 
 if __name__ == '__main__':

--- a/tests/integrated/test_advertising.py
+++ b/tests/integrated/test_advertising.py
@@ -1,18 +1,18 @@
 import threading
+import time
 import unittest
 
 from blatann.gap.advertise_data import AdvertisingData, AdvertisingFlags
 from blatann.gap.advertising import AdvertisingMode
 from blatann.gap.scanning import ScanReport, Scanner
 from blatann.utils import Stopwatch
-from blatann.event_type import event_subscriber
 
 from tests.integrated.base import BlatannTestCase, TestParams, long_running
 
 
 class TestAdvertising(BlatannTestCase):
     def setUp(self) -> None:
-        self.adv_interval_ms = 250
+        self.adv_interval_ms = 50
         self.adv_duration = 5
         self.adv_mode = AdvertisingMode.non_connectable_undirected
         self.adv_data = AdvertisingData(flags=0x06, local_name="Blatann Test")
@@ -25,9 +25,10 @@ class TestAdvertising(BlatannTestCase):
         self.dev2.scanner.stop()
 
     @long_running
-    @TestParams([dict(duration=x) for x in [1, 4, 8, 10, 15, 22, 30, 60]])
+    @TestParams([dict(duration=x) for x in [1, 4, 8, 10]])
     def test_advertise_duration(self, duration):
         acceptable_delta = 0.100
+        acceptable_delta_scan = 1.000
         scan_stopwatch = Stopwatch()
         dev1_addr = self.dev1.address
 
@@ -39,22 +40,23 @@ class TestAdvertising(BlatannTestCase):
             else:
                 scan_stopwatch.start()
 
-        self.dev2.scanner.set_default_scan_params(50, 50, duration+2)
+        self.dev2.scanner.set_default_scan_params(100, 100, duration+2, False)
 
-        with event_subscriber(self.dev2.scanner.on_scan_received, on_scan_report):
+        with self.dev2.scanner.on_scan_received.register(on_scan_report):
             self.dev2.scanner.start_scan()
-            with Stopwatch() as stopwatch:
-                w = self.dev1.advertiser.start(timeout_sec=duration)
-                w.wait(duration + 2)
-            self.dev2.scanner.stop()
+            with Stopwatch() as wait_stopwatch:
+                self.dev1.advertiser.start(timeout_sec=duration, auto_restart=False).wait(duration + 2)
 
+        self.assertFalse(wait_stopwatch.is_running)
         self.assertFalse(self.dev1.advertiser.is_advertising)
 
-        wait_delta = abs(duration - stopwatch.elapsed)
+        wait_delta = abs(duration - wait_stopwatch.elapsed)
         self.assertLessEqual(wait_delta, acceptable_delta)
 
         scan_delta = abs(duration - scan_stopwatch.elapsed)
-        self.assertLessEqual(scan_delta, acceptable_delta)
+        self.assertLessEqual(scan_delta, acceptable_delta_scan)
+
+        self.logger.info("Wait Delta: {:.3f}, Scan Delta: {:.3f}".format(wait_delta, scan_delta))
 
     @TestParams([dict(duration=x) for x in [1, 2, 4]])
     def test_advertise_duration_timeout_event(self, duration):
@@ -64,9 +66,9 @@ class TestAdvertising(BlatannTestCase):
         def on_timeout(*args, **kwargs):
             on_timeout_event.set()
 
-        with event_subscriber(self.dev1.advertiser.on_advertising_timeout, on_timeout):
+        with self.dev1.advertiser.on_advertising_timeout.register(on_timeout):
             with Stopwatch() as stopwatch:
-                self.dev1.advertiser.start(timeout_sec=duration)
+                self.dev1.advertiser.start(timeout_sec=duration, auto_restart=False)
                 on_timeout_event.wait(duration + 2)
 
         self.assertTrue(on_timeout_event.is_set())
@@ -74,11 +76,34 @@ class TestAdvertising(BlatannTestCase):
 
         actual_delta = abs(duration - stopwatch.elapsed)
         self.assertLessEqual(actual_delta, acceptable_delta)
+        self.logger.info("Delta: {:.3f}".format(actual_delta))
 
-    @TestParams([dict(interval_ms=x) for x in [50, 100, 200]])
-    def test_advertising_interval(self, interval_ms):
-        self.dev2.scanner.set_default_scan_params(50, 50, self.adv_duration + 2)
+    def test_advertise_auto_restart(self):
+        # Scan for longer than the advertising duration,
+        # but with auto-restart it should advertise for the full scan duration
+        scan_duration = 10
+        advertise_duration = 2
+        acceptable_delta = 0.500
+        dev1_addr = self.dev1.address
 
+        self.dev2.scanner.set_default_scan_params(100, 100, scan_duration, False)
+
+        w = self.dev2.scanner.start_scan()
+        self.dev1.advertiser.start(timeout_sec=advertise_duration, auto_restart=True)
+        w.wait()
+
+        self.dev1.advertiser.stop()
+        self.dev2.scanner.stop()
+
+        report_timestamps = [r.timestamp for r in self.dev2.scanner.scan_report.all_scan_reports
+                             if r.peer_address == dev1_addr]
+        self.assertGreater(len(report_timestamps), 0)
+
+        report_seen_duration = report_timestamps[-1] - report_timestamps[0]
+
+        delta = abs(report_seen_duration - scan_duration)
+        self.assertLessEqual(delta, acceptable_delta)
+        self.logger.info("Delta: {:.3f}".format(delta))
 
 
 if __name__ == '__main__':

--- a/tests/integrated/test_advertising_data.py
+++ b/tests/integrated/test_advertising_data.py
@@ -160,3 +160,7 @@ class TestAdvertisingData(BlatannTestCase):
             self.assertEqual(expected_service_data, packet.advertise_data.service_data)
 
     # TODO 04.20.20: Add more tests around data content (128-bit uuid, service data, mfg data, etc.)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/integrated/test_advertising_data.py
+++ b/tests/integrated/test_advertising_data.py
@@ -1,0 +1,162 @@
+import unittest
+import time
+
+from blatann.uuid import Uuid16
+
+from blatann.gap.advertise_data import AdvertisingData, AdvertisingFlags, AdvertisingPacketType
+from blatann.gap.advertising import AdvertisingMode
+from blatann.gap.scanning import ScanReport, Scanner
+from blatann.services.nordic_uart import NORDIC_UART_SERVICE_UUID
+
+from tests.integrated.base import BlatannTestCase, TestParams, long_running
+
+
+class TestAdvertisingData(BlatannTestCase):
+    def setUp(self) -> None:
+        self.adv_interval_ms = 50
+        self.adv_duration = 5
+        self.adv_mode = AdvertisingMode.scanable_undirected
+        self.flags = AdvertisingFlags.GENERAL_DISCOVERY_MODE | AdvertisingFlags.BR_EDR_NOT_SUPPORTED
+        self._configure_adv()
+        self._configure_scan()
+        self.adv_mac_addr = self.dev1.address
+        self.uuid16s = [Uuid16(0xABCD), Uuid16(0xDEF0)]
+        self.uuid128 = NORDIC_UART_SERVICE_UUID
+        self.default_adv_data = AdvertisingData(flags=self.flags, local_name="Blatann Test")
+        self.default_adv_data_bytes = self.default_adv_data.to_bytes()
+        self.default_scan_data = AdvertisingData(service_uuid16s=self.uuid16s)
+        self.default_scan_data_bytes = self.default_scan_data.to_bytes()
+
+    def _configure_adv(self, duration=10, adv_mode=AdvertisingMode.scanable_undirected):
+        self.adv_mode = adv_mode
+        self.dev1.advertiser.set_default_advertise_params(25, duration, self.adv_mode)
+
+    def _configure_scan(self, duration=4, active_scan=True):
+        self.dev2.scanner.set_default_scan_params(100, 100, duration, True)
+
+    def _get_packets_for_adv(self, results):
+        all_packets = [p for p in results.all_scan_reports if p.peer_address == self.adv_mac_addr]
+        adv_packets = [p for p in all_packets if p.packet_type == self.adv_mode]
+        scan_response_packets = [p for p in all_packets if p.packet_type == AdvertisingPacketType.scan_response]
+
+        return all_packets, adv_packets, scan_response_packets
+
+    def tearDown(self) -> None:
+        self.dev1.advertiser.stop()
+        self.dev2.scanner.stop()
+        time.sleep(0.5)
+
+    def test_advertising_no_scan_data(self):
+        self.dev1.advertiser.set_advertise_data(self.default_adv_data)
+        self.dev1.advertiser.start()
+        results = self.dev2.scanner.start_scan(clear_scan_reports=True).wait(10)
+
+        # Get the list of all advertising packets from the advertiser
+        all_packets, adv_packets, scan_response_packets = self._get_packets_for_adv(results)
+        self.assertGreater(len(all_packets), 0)
+        self.assertGreater(len(adv_packets), 0)
+        self.assertGreater(len(scan_response_packets), 0)
+        self.assertEqual(len(scan_response_packets), len(all_packets) - len(adv_packets))
+
+        # Check the contents of the received advertising packets to make sure they are the same
+        for packet in adv_packets:
+            if packet.packet_type == AdvertisingPacketType.scan_response:
+                # Scan responses should be empty
+                self.assertEqual(b"", packet.raw_bytes)
+            else:
+                self.assertEqual(self.default_adv_data_bytes, packet.raw_bytes)
+
+    def test_advertising_scan_data(self):
+        self.dev1.advertiser.set_advertise_data(self.default_adv_data, self.default_scan_data)
+        self.dev1.advertiser.start()
+
+        results = self.dev2.scanner.start_scan(clear_scan_reports=True).wait(10)
+
+        # Get the list of all advertising packets from the advertiser
+        all_packets, adv_packets, scan_response_packets = self._get_packets_for_adv(results)
+        self.assertGreater(len(all_packets), 0)
+        self.assertGreater(len(adv_packets), 0)
+        self.assertGreater(len(scan_response_packets), 0)
+        self.assertEqual(len(scan_response_packets), len(all_packets) - len(adv_packets))
+
+        # Check the contents of the received advertising packets to make sure they are the same
+        for packet in adv_packets:
+            if packet.packet_type == AdvertisingPacketType.scan_response:
+                self.assertEqual(self.default_scan_data_bytes, packet.raw_bytes)
+            else:
+                self.assertEqual(self.default_adv_data_bytes, packet.raw_bytes)
+
+        # Check the combined report that all the fields are included
+        combined_report = [p for p in results.advertising_peers_found if p.peer_address == self.adv_mac_addr]
+        self.assertEqual(1, len(combined_report))
+        adv_data = combined_report[0].advertise_data
+        self.assertEqual(self.default_adv_data.flags, adv_data.flags)
+        self.assertEqual(self.default_adv_data.local_name, adv_data.local_name)
+        self.assertEqual(self.default_scan_data.service_uuid16s, adv_data.service_uuid16s)
+
+    def test_non_active_scanning_no_scan_response_packets_received(self):
+        self.dev1.advertiser.set_advertise_data(self.default_adv_data, self.default_scan_data)
+        self.dev1.advertiser.start()
+        self._configure_scan(active_scan=False)
+        self.dev2.scanner.set_default_scan_params(100, 100, 5, active_scanning=False)
+        results = self.dev2.scanner.start_scan(clear_scan_reports=True).wait(10)
+
+        # Get the list of all advertising packets from the advertiser
+        all_packets, adv_packets, scan_response_packets = self._get_packets_for_adv(results)
+        self.assertGreater(len(all_packets), 0)
+        self.assertEqual(len(all_packets), len(adv_packets))
+        self.assertEqual(0, len(scan_response_packets))
+
+        for p in adv_packets:
+            self.assertEqual(self.default_adv_data_bytes, p.raw_bytes)
+
+    def test_non_connectable_undirected_no_scan_response_packets_received(self):
+        self._configure_adv(adv_mode=AdvertisingMode.non_connectable_undirected)
+        self.dev1.advertiser.set_advertise_data(self.default_adv_data, self.default_scan_data)
+        self.dev1.advertiser.start()
+        self.dev2.scanner.set_default_scan_params(100, 100, 5, active_scanning=False)
+        results = self.dev2.scanner.start_scan(clear_scan_reports=True).wait(10)
+
+        # Get the list of all advertising packets from the advertiser
+        all_packets, adv_packets, scan_response_packets = self._get_packets_for_adv(results)
+        self.assertGreater(len(all_packets), 0)
+        self.assertEqual(len(all_packets), len(adv_packets))
+        self.assertEqual(0, len(scan_response_packets))
+
+        for p in adv_packets:
+            self.assertEqual(self.default_adv_data_bytes, p.raw_bytes)
+
+    def test_dynamic_adv_data_update(self):
+        self._configure_adv(duration=20, adv_mode=AdvertisingMode.non_connectable_undirected)
+        self._configure_scan(10)
+        service_data = [0xAB, 0xCD, 0x00]
+        service_data_preamble = service_data[:-1]
+        iterations = 10
+        adv_data = AdvertisingData(service_data=service_data)
+        self.dev1.advertiser.set_advertise_data(adv_data)
+        self.dev1.advertiser.start()
+        self.dev2.scanner.start_scan()
+
+        for i in range(iterations):
+            time.sleep(0.5)
+            adv_data.service_data[-1] += 1
+            self.dev1.advertiser.set_advertise_data(adv_data)
+
+        time.sleep(0.5)
+        self.dev2.scanner.stop()
+        self.dev1.advertiser.stop()
+
+        results = self.dev2.scanner.scan_report
+
+        all_packets, adv_packets, scan_response_packets = self._get_packets_for_adv(results)
+        self.assertGreater(len(all_packets), 0)
+        self.assertEqual(len(all_packets), len(adv_packets))
+        self.assertEqual(0, len(scan_response_packets))
+        non_dupes = [p for p in adv_packets if not p.duplicate]
+
+        self.assertEqual(iterations+1, len(non_dupes))
+        for i, packet in enumerate(non_dupes):
+            expected_service_data = bytes(service_data_preamble + [i])
+            self.assertEqual(expected_service_data, packet.advertise_data.service_data)
+
+    # TODO 04.20.20: Add more tests around data content (128-bit uuid, service data, mfg data, etc.)

--- a/tests/integrated/test_advertising_duration.py
+++ b/tests/integrated/test_advertising_duration.py
@@ -1,5 +1,4 @@
 import threading
-import time
 import unittest
 
 from blatann.gap.advertise_data import AdvertisingData, AdvertisingFlags
@@ -10,7 +9,7 @@ from blatann.utils import Stopwatch
 from tests.integrated.base import BlatannTestCase, TestParams, long_running
 
 
-class TestAdvertising(BlatannTestCase):
+class TestAdvertisingDuration(BlatannTestCase):
     def setUp(self) -> None:
         self.adv_interval_ms = 50
         self.adv_duration = 5


### PR DESCRIPTION
- Adds tests around advertising data, integrates a second scanner device to verify over-air data and durations
- Adds a couple features around advertising/scanning
  - Active scanning is now configurable
  - Can now get the raw advertising payload in `bytes`
  - Adds a context manager returned from `event.register()` so it can be used as `with some_event.register(handler):`
- Adds the serial port name to the driver function call log messages (for multi-device setups)
- Fixes some issues around restarting advertising
- Cleans up the AdvertisingData class a bit (api should be backwards compatible)