### PR TITLE
add pc-ble-driver-py to docs/requirements.txt

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,2 @@
 sphinx-autodoc-typehints
+pc-ble-driver-py


### PR DESCRIPTION
Need deps to be installed for the autodoc to work on readthedocs. For some reason the `pc-ble-driver-py>=0.13` version specifier in the normal requirements.txt isn't working so adding it here without version specifier to be installed