### PR TITLE
Fix: Characteristics with `write without response` property

### DIFF
--- a/blatann/gatt/gatts.py
+++ b/blatann/gatt/gatts.py
@@ -381,9 +381,15 @@ class GattsService(gatt.Service):
         self.ble_device.uuid_manager.register_uuid(uuid)
 
         # Create property structure
-        props = nrf_types.BLEGattCharacteristicProperties(properties.broadcast, properties.read, False,
-                                                          properties.write, properties.notify, properties.indicate,
-                                                          False)
+        props = nrf_types.BLEGattCharacteristicProperties(
+            broadcast=properties.broadcast,
+            read=properties.read,
+            write_wo_resp=properties.write_no_response,
+            write=properties.write,
+            notify=properties.notify,
+            indicate=properties.indicate,
+            auth_signed_wr=False
+        )
         # Create cccd metadata if notify/indicate enabled
         if properties.notify or properties.indicate:
             cccd_metadata = nrf_types.BLEGattsAttrMetadata(read_auth=False, write_auth=False)


### PR DESCRIPTION
It was not possible to add a characteristic with `write without response` properties, because it was hard coded to `False`.
Fixed it, so the given `properties.write_no_response` value is now respected 😉