### PR TITLE
adds support for performing write without responses as a GATT Client

### DIFF
--- a/blatann/device.py
+++ b/blatann/device.py
@@ -27,7 +27,7 @@ class _EventLogger(NrfDriverObserver):
     def on_driver_event(self, nrf_driver, event):
         with self._lock:
             if type(event) not in self._suppressed_events:
-                logger.debug("Got NRF Driver event: {}".format(event))
+                logger.debug("Got NRF Driver event: %s", event)
 
 
 class _UuidManager(object):

--- a/blatann/device.py
+++ b/blatann/device.py
@@ -92,7 +92,7 @@ class BleDevice(NrfDriverObserver):
         self.ble_driver.observer_register(self)
         self.ble_driver.event_subscribe(self._on_user_mem_request, nrf_events.EvtUserMemoryRequest)
         self._ble_configuration = self.ble_driver.ble_enable_params_setup()
-        self._default_conn_config = nrf_types.BleConnConfig(event_length=6)
+        self._default_conn_config = nrf_types.BleConnConfig(event_length=6)  # The minimum event length which supports max DLE
 
         self.bond_db_loader = default_bond_db.DefaultBondDatabaseLoader()
         self.bond_db = default_bond_db.DefaultBondDatabase()

--- a/blatann/device.py
+++ b/blatann/device.py
@@ -92,7 +92,7 @@ class BleDevice(NrfDriverObserver):
         self.ble_driver.observer_register(self)
         self.ble_driver.event_subscribe(self._on_user_mem_request, nrf_events.EvtUserMemoryRequest)
         self._ble_configuration = self.ble_driver.ble_enable_params_setup()
-        self._default_conn_config = nrf_types.BleConnConfig()
+        self._default_conn_config = nrf_types.BleConnConfig(event_length=6)
 
         self.bond_db_loader = default_bond_db.DefaultBondDatabaseLoader()
         self.bond_db = default_bond_db.DefaultBondDatabase()

--- a/blatann/event_args.py
+++ b/blatann/event_args.py
@@ -47,6 +47,26 @@ class DisconnectionEventArgs(EventArgs):
         self.reason = reason
 
 
+class MtuSizeUpdatedEventArgs(EventArgs):
+    """
+    Event arguments for when the effective MTU size on a connection is updated
+    """
+    def __init__(self, previous_mtu_size: int, current_mtu_size: int):
+        self.previous_mtu_size = previous_mtu_size
+        self.current_mtu_size = current_mtu_size
+
+
+class DataLengthUpdatedEventArgs(EventArgs):
+    """
+    Event arguments for when the Data Length of the link layer has been changed
+    """
+    def __init__(self, tx_bytes: int, rx_bytes: int, tx_time_us: int, rx_time_us: int):
+        self.tx_bytes = tx_bytes
+        self.rx_bytes = rx_bytes
+        self.tx_time_us = tx_time_us
+        self.rx_time_us = rx_time_us
+
+
 # SMP Event Args
 
 class PairingCompleteEventArgs(EventArgs):
@@ -285,12 +305,3 @@ class DecodedReadCompleteEventArgs(ReadCompleteEventArgs, Generic[TDecodedValue]
         return DecodedReadCompleteEventArgs(read_complete_event_args.id, read_complete_event_args.value,
                                             read_complete_event_args.status, read_complete_event_args.reason,
                                             decoded_stream)
-
-
-class MtuSizeUpdatedEventArgs(EventArgs):
-    """
-    Event arguments for when the effective MTU size on a connection is updated
-    """
-    def __init__(self, previous_mtu_size: int, current_mtu_size: int):
-        self.previous_mtu_size = previous_mtu_size
-        self.current_mtu_size = current_mtu_size

--- a/blatann/gatt/gatts.py
+++ b/blatann/gatt/gatts.py
@@ -6,6 +6,7 @@ import threading
 import binascii
 from blatann.nrf import nrf_types, nrf_events
 from blatann import gatt
+from blatann.utils import SynchronousMonotonicCounter
 from blatann.uuid import Uuid
 from blatann.waitables.event_waitable import IdBasedEventWaitable, EventWaitable
 from blatann.exceptions import InvalidOperationException, InvalidStateException
@@ -488,13 +489,10 @@ class GattsDatabase(gatt.GattDatabase):
 
 
 class _Notification(object):
-    _id_counter = 0
-    _lock = threading.Lock()
+    _id_generator = SynchronousMonotonicCounter(1)
 
     def __init__(self, characteristic, handle, on_complete, data):
-        with _Notification._lock:
-            self.id = _Notification._id_counter
-            _Notification._id_counter += 1
+        self.id = _Notification._id_generator.next()
         self.char = characteristic
         self.handle = handle
         self.on_complete = on_complete

--- a/blatann/gatt/writer.py
+++ b/blatann/gatt/writer.py
@@ -2,7 +2,7 @@ import logging
 from blatann.event_type import EventSource, Event
 from blatann.nrf import nrf_types, nrf_events
 from blatann.waitables.event_waitable import EventWaitable
-from blatann.exceptions import InvalidStateException
+from blatann.exceptions import InvalidStateException, InvalidOperationException
 from blatann.event_args import EventArgs
 
 logger = logging.getLogger(__name__)
@@ -35,6 +35,7 @@ class GattcWriter(object):
         self._handle = 0x0000
         self._offset = 0
         self.peer.driver_event_subscribe(self._on_write_response, nrf_events.GattcEvtWriteResponse)
+        self.peer.driver_event_subscribe(self._on_write_tx_complete, nrf_events.GattcEvtWriteCmdTxComplete)
         self._len_bytes_written = 0
 
     @property
@@ -49,13 +50,15 @@ class GattcWriter(object):
         """
         return self._on_write_complete
 
-    def write(self, handle, data):
+    def write(self, handle, data, with_response=True):
         """
         Writes data to the attribute at the handle provided. Can only write to a single attribute at a time.
         If a write is in progress, raises an InvalidStateException
 
         :param handle: The attribute handle to write
         :param data: The data to write
+        :param with_response: True to do a BLE Request operation write which requires a confirmation response from the peripheral.
+                              False to do a BLE Command operation which does not have a response from the peripheral
         :return: A Waitable that will fire when the write finishes. see on_write_complete for the values returned from the waitable
         :rtype: EventWaitable
         """
@@ -63,13 +66,33 @@ class GattcWriter(object):
             raise InvalidStateException("Gattc Writer is busy")
         if len(data) == 0:
             raise ValueError("Data must be at least one byte")
+
         self._offset = 0
         self._handle = handle
         self._data = data
         logger.debug("Starting write to handle {}, len: {}".format(self._handle, len(self._data)))
-        self._write_next_chunk()
-        self._busy = True
+        try:
+            self._busy = True
+            if with_response:
+                self._write_next_chunk()
+            else:
+                self._write_no_response()
+        except Exception:
+            self._busy = False
+            raise
         return EventWaitable(self.on_write_complete)
+
+    def _write_no_response(self):
+        # Verify that the write can fit into a single MTU
+        data_len = len(self._data)
+        if data_len > self.peer.mtu_size - self._WRITE_OVERHEAD:
+            raise InvalidOperationException(f"Writing data without response must fit within a "
+                                            f"single MTU minus the write overhead ({self._WRITE_OVERHEAD} bytes). "
+                                            f"MTU: {self.peer.mtu_size}bytes, data: {data_len}bytes")
+        write_operation = nrf_types.BLEGattWriteOperation.write_cmd
+        flags = nrf_types.BLEGattExecWriteFlag.unused
+        write_params = nrf_types.BLEGattcWriteParams(write_operation, flags, self._handle, self._data, self._offset)
+        self.ble_device.ble_driver.ble_gattc_write(self.peer.conn_handle, write_params)
 
     def _write_next_chunk(self):
         flags = nrf_types.BLEGattExecWriteFlag.unused
@@ -92,12 +115,10 @@ class GattcWriter(object):
                                                                                      len(data_to_write), write_operation))
         self.ble_device.ble_driver.ble_gattc_write(self.peer.conn_handle, write_params)
 
-    def _on_write_response(self, driver, event):
-        """
-        Handler for GattcEvtWriteResponse
+    def _on_write_tx_complete(self, driver, event: nrf_events.GattcEvtWriteCmdTxComplete):
+        self._complete()
 
-        :type event: nrf_events.GattcEvtWriteResponse
-        """
+    def _on_write_response(self, driver, event: nrf_events.GattcEvtWriteResponse):
         if event.conn_handle != self.peer.conn_handle:
             return
         if event.attr_handle != self._handle and event.write_op != nrf_types.BLEGattWriteOperation.execute_write_req:

--- a/blatann/nrf/nrf_driver.py
+++ b/blatann/nrf/nrf_driver.py
@@ -61,7 +61,7 @@ def NordicSemiErrorCheck(wrapped=None, expected=driver.NRF_SUCCESS):
 
     @wrapt.decorator
     def wrapper(wrapped, instance, args, kwargs):
-        logger.debug("[{}] {}{}".format(instance.serial_port, wrapped.__name__, args))
+        logger.debug("[%s] %s%s", instance.serial_port, wrapped.__name__, args)
         result = wrapped(*args, **kwargs)
         if isinstance(result, (list, tuple)):
             err_code = result[0]

--- a/blatann/nrf/nrf_events/__init__.py
+++ b/blatann/nrf/nrf_events/__init__.py
@@ -40,11 +40,11 @@ _event_classes = [
     GattcEvtAttrInfoDiscoveryResponse,
     GattcEvtMtuExchangeResponse,
     GattcEvtTimeout,
+    GattcEvtWriteCmdTxComplete,
     # TODO:
     # driver.BLE_GATTC_EVT_REL_DISC_RSP
     # driver.BLE_GATTC_EVT_CHAR_VAL_BY_UUID_READ_RSP
     # driver.BLE_GATTC_EVT_CHAR_VALS_READ_RSP
-    # driver.BLE_GATTC_EVT_WRITE_CMD_TX_COMPLETE
 
     # Gatts
     GattsEvtWrite,

--- a/blatann/nrf/nrf_events/gatt_events.py
+++ b/blatann/nrf/nrf_events/gatt_events.py
@@ -1,5 +1,3 @@
-from enum import IntEnum
-
 from blatann.nrf.nrf_types import *
 from blatann.nrf.nrf_dll_load import driver
 import blatann.nrf.nrf_driver_types as util
@@ -58,9 +56,8 @@ class GattcEvtReadResponse(GattcEvt):
         data = None
         if self.data is not None:
             data = ''.join(map(chr, self.data))
-        return "{}(conn_handle={!r}, status={!r}, error_handle={!r}, attr_handle={!r}, offset={!r}, data={!r})".format(
-            self.__class__.__name__, self.conn_handle,
-            self.status, self.error_handle, self.attr_handle, self.offset, data)
+        return self._repr_format(status=self.status, error_handle=self.error_handle, attr_handle=self.attr_handle,
+                                 offset=self.offset, data=data)
 
 
 class GattcEvtHvx(GattcEvt):
@@ -89,9 +86,26 @@ class GattcEvtHvx(GattcEvt):
 
     def __repr__(self):
         data = ''.join(map(chr, self.data))
-        return "{}(conn_handle={!r}, status={!r}, error_handle={!r}, attr_handle={!r}, hvx_type={!r}, data={!r})".format(
-            self.__class__.__name__, self.conn_handle,
-            self.status, self.error_handle, self.attr_handle, self.hvx_type, data)
+        return self._repr_format(status=self.status, error_handle=self.error_handle,
+                                 attr_handle=self.attr_handle,
+                                 hvx_type=self.hvx_type, data=data)
+
+
+class GattcEvtWriteCmdTxComplete(GattcEvt):
+    evt_id = driver.BLE_GATTC_EVT_WRITE_CMD_TX_COMPLETE
+
+    def __init__(self, conn_handle, count):
+        super(GattcEvtWriteCmdTxComplete, self).__init__(conn_handle)
+        self.count = count
+
+    @classmethod
+    def from_c(cls, event):
+        tx_evt = event.evt.gattc_evt.params.write_cmd_tx_complete
+        return cls(conn_handle=event.evt.gattc_evt.conn_handle,
+                   count=tx_evt.count)
+
+    def __repr__(self):
+        return self._repr_format(count=self.count)
 
 
 class GattcEvtWriteResponse(GattcEvt):
@@ -122,9 +136,8 @@ class GattcEvtWriteResponse(GattcEvt):
 
     def __repr__(self):
         data = ''.join(map(chr, self.data))
-        return "{}(conn_handle={!r}, status={!r}, error_handle={!r}, attr_handle={!r}, write_op={!r}, offset={!r}, data={!r})".format(
-            self.__class__.__name__, self.conn_handle,
-            self.status, self.error_handle, self.attr_handle, self.write_op, self.offset, data)
+        return self._repr_format(status=self.status, error_handle=self.error_handle, attr_handle=self.attr_handle,
+                                 write_of=self.write_op, offset=self.offset, data=data)
 
 
 class GattcEvtPrimaryServiceDiscoveryResponse(GattcEvt):
@@ -148,8 +161,7 @@ class GattcEvtPrimaryServiceDiscoveryResponse(GattcEvt):
                    services=services)
 
     def __repr__(self):
-        return "{}(conn_handle={!r}, status={!r}, services={!r})".format(self.__class__.__name__, self.conn_handle,
-                                                                         self.status, self.services)
+        return self._repr_format(status=self.status, services=self.services)
 
 
 class GattcEvtCharacteristicDiscoveryResponse(GattcEvt):

--- a/blatann/nrf/nrf_events/gatt_events.py
+++ b/blatann/nrf/nrf_events/gatt_events.py
@@ -314,9 +314,8 @@ class GattsEvtWrite(GattsEvt):
         return cls(conn_handle, attr_handle, uuid, write_operand, auth_required, offset, data)
 
     def __repr__(self):
-        return "{}(conn_handle={!r}, attr_handle={!r}, uuid={!r}, write_op={!r}, auth_required={!r}, offset={!r}, " \
-               "data={!r})".format(self.__class__.__name__, self.conn_handle, self.attribute_handle, self.uuid,
-                                   self.write_op, self.auth_required, self.offset, self.data)
+        return self._repr_format(attr_handle=self.attribute_handle, uuid=self.uuid, write_op=self.write_op,
+                                 auth_required=self.auth_required, offset=self.offset, data=bytes(self.data))
 
 
 class GattsEvtRead(GattsEvt):  # Not a _true_ event, but is used for the Read/Write event class

--- a/blatann/nrf/nrf_events/generic_events.py
+++ b/blatann/nrf/nrf_events/generic_events.py
@@ -14,9 +14,11 @@ class BLEEvent(object):
     def __str__(self):
         return self.__repr__()
 
-    def _repr_format(self, *args, **kwargs):
-        kwargs["conn_handle"] = self.conn_handle
-        items = list(args) + ["{}={}".format(k, v) for k, v in kwargs.items()]
+    def _repr_format(self, **kwargs):
+        """
+        Helper method to format __repr__ for BLE events
+        """
+        items = ["conn_handle={}".format(self.conn_handle)] + ["{}={}".format(k, v) for k, v in kwargs.items()]
         inner = ", ".join(items)
         return "{}({})".format(self.__class__.__name__, inner)
 
@@ -33,4 +35,4 @@ class EvtUserMemoryRequest(BLEEvent):
         return cls(event.evt.common_evt.conn_handle, event.evt.common_evt.params.user_mem_request.type)
 
     def __repr__(self):
-        return "{}(conn_handle={!r}, type={!r})".format(self.__class__.__name__, self.conn_handle, self.type)
+        return self._repr_format(type=self.type)

--- a/blatann/nrf/nrf_events/generic_events.py
+++ b/blatann/nrf/nrf_events/generic_events.py
@@ -2,7 +2,8 @@ from enum import IntEnum
 
 from blatann.nrf.nrf_types import *
 from blatann.nrf.nrf_dll_load import driver
-import blatann.nrf.nrf_driver_types as util
+import blatann.nrf.nrf_driver_types
+from blatann.utils import repr_format
 
 
 class BLEEvent(object):
@@ -18,9 +19,7 @@ class BLEEvent(object):
         """
         Helper method to format __repr__ for BLE events
         """
-        items = ["conn_handle={}".format(self.conn_handle)] + ["{}={}".format(k, v) for k, v in kwargs.items()]
-        inner = ", ".join(items)
-        return "{}({})".format(self.__class__.__name__, inner)
+        return repr_format(self, conn_handle=self.conn_handle, **kwargs)
 
 
 class EvtUserMemoryRequest(BLEEvent):

--- a/blatann/nrf/nrf_types/gatt.py
+++ b/blatann/nrf/nrf_types/gatt.py
@@ -5,6 +5,7 @@ import blatann.nrf.nrf_driver_types as util
 from blatann.nrf.nrf_types.generic import BLEUUID, BLEUUIDBase
 from blatann.nrf.nrf_types.smp import *
 from blatann.nrf.nrf_types.enums import *
+from blatann.utils import repr_format
 
 logger = logging.getLogger(__name__)
 
@@ -154,6 +155,10 @@ class BLEGattcWriteParams(object):
         write_params.write_op = self.write_op.value
 
         return write_params
+
+    def __repr__(self):
+        return repr_format(self, handle=self.handle, write_op=self.write_op, offset=self.offset,
+                           flags=self.flags, data=self.data)
 
 
 class BLEGattcDescriptor(object):
@@ -343,6 +348,9 @@ class BLEGattsAuthorizeParams(object):
 
         return params
 
+    def __repr__(self):
+        return repr_format(self, gatt_status=self.gatt_status, update=self.update, offset=self.offset)
+
 
 class BLEGattsRwAuthorizeReplyParams(object):
     def __init__(self, read=None, write=None):
@@ -366,6 +374,12 @@ class BLEGattsRwAuthorizeReplyParams(object):
             params.type = driver.BLE_GATTS_AUTHORIZE_TYPE_WRITE
             params.params.write = self.write.to_c()
         return params
+
+    def __repr__(self):
+        if self.read:
+            return repr_format(self, read=self.read)
+        else:
+            return repr_format(self, write=self.write)
 
 
 class BLEGattsValue(object):
@@ -413,3 +427,6 @@ class BLEGattsHvx(object):
         params.offset = self.offset
         params.p_len = self._len_ptr  # TODO: Not sure if this works
         return params
+
+    def __repr__(self):
+        return repr_format(self, handle=self.handle, type=self.type, offset=self.offset, data=self.data)

--- a/blatann/peer.py
+++ b/blatann/peer.py
@@ -8,7 +8,7 @@ from blatann.gap import smp
 from blatann.gatt import gattc, service_discovery, MTU_SIZE_DEFAULT, MTU_SIZE_MINIMUM
 from blatann.nrf import nrf_events
 from blatann.nrf.nrf_types.enums import BLE_CONN_HANDLE_INVALID
-from blatann.nrf.nrf_types import conn_interval_range, conn_timeout_range
+from blatann.nrf.nrf_types import conn_interval_range, conn_timeout_range, BLEGapDataLengthParams
 from blatann.waitables.waitable import EmptyWaitable
 from blatann.waitables.connection_waitable import DisconnectionWaitable
 from blatann.waitables.event_waitable import EventWaitable
@@ -115,6 +115,7 @@ class Peer(object):
         self._on_disconnect = EventSource("On Disconnect", logger)
         self._on_mtu_exchange_complete = EventSource("On MTU Exchange Complete", logger)
         self._on_mtu_size_updated = EventSource("On MTU Size Updated", logger)
+        self._on_data_length_updated = EventSource("On Data Length Updated", logger)
         self._mtu_size = MTU_SIZE_DEFAULT
         self._preferred_mtu_size = MTU_SIZE_DEFAULT
         self._negotiated_mtu_size = None
@@ -261,6 +262,13 @@ class Peer(object):
         return self._on_mtu_size_updated
 
     @property
+    def on_data_length_updated(self) -> Event[Peer, DataLengthUpdatedEventArgs]:
+        """
+        Event generated when the link layer data length has been updated
+        """
+        return self._on_data_length_updated
+
+    @property
     def on_database_discovery_complete(self) -> Event[Peripheral, DatabaseDiscoveryCompleteEventArgs]:
         """
         Event that is triggered when database discovery has completed
@@ -328,6 +336,16 @@ class Peer(object):
         self._ble_device.ble_driver.ble_gattc_exchange_mtu_req(self.conn_handle, self._negotiated_mtu_size)
         return EventWaitable(self._on_mtu_exchange_complete)
 
+    def update_data_length(self) -> EventWaitable[Peripheral, DataLengthUpdatedEventArgs]:
+        """
+        Starts the process which updates the link layer data length to the optimal value given the MTU.
+        For best results call this method after the MTU is set to the desired size.
+
+        :return: A waitable that will fire when the process finishes
+        """
+        self._ble_device.ble_driver.ble_gap_data_length_update(self.conn_handle)
+        return EventWaitable(self._on_data_length_updated)
+
     def discover_services(self) -> EventWaitable[Peripheral, DatabaseDiscoveryCompleteEventArgs]:
         """
         Starts the database discovery process of the peer. This will discover all services, characteristics, and
@@ -360,6 +378,7 @@ class Peer(object):
         self.driver_event_subscribe(self._on_mtu_exchange_request, nrf_events.GattsEvtExchangeMtuRequest)
         self.driver_event_subscribe(self._on_mtu_exchange_response, nrf_events.GattcEvtMtuExchangeResponse)
         self.driver_event_subscribe(self._on_data_length_update_request, nrf_events.GapEvtDataLengthUpdateRequest)
+        self.driver_event_subscribe(self._on_data_length_update, nrf_events.GapEvtDataLengthUpdate)
         self.driver_event_subscribe(self._on_phy_update_request, nrf_events.GapEvtPhyUpdateRequest)
         self._on_connect.notify(self)
 
@@ -467,6 +486,11 @@ class Peer(object):
 
     def _on_data_length_update_request(self, driver, event):
         self._ble_device.ble_driver.ble_gap_data_length_update(self.conn_handle)
+
+    def _on_data_length_update(self, driver, event):
+        event_args = DataLengthUpdatedEventArgs(event.max_tx_octets, event.max_rx_octets,
+                                                event.max_tx_time_us, event.max_rx_time_us)
+        self._on_data_length_updated.notify(self, event_args)
 
     def _on_phy_update_request(self, driver, event):
         self._ble_device.ble_driver.ble_gap_phy_update(self.conn_handle)

--- a/blatann/peer.py
+++ b/blatann/peer.py
@@ -389,7 +389,6 @@ class Peer(object):
             :type event: blatann.nrf.nrf_events.BLEEvent
             """
             if self.connected and self.conn_handle == event.conn_handle:
-                logger.debug("Got event: {} for peer {}".format(event, self.conn_handle))
                 func(driver, event)
         return wrapper
 

--- a/blatann/utils/__init__.py
+++ b/blatann/utils/__init__.py
@@ -18,6 +18,21 @@ def setup_logger(name=None, level="DEBUG"):
     return logger
 
 
+def repr_format(obj, *args, **kwargs):
+    """
+    Helper function to format objects into strings in the format of:
+    ClassName(param1=value1, param2=value2, ...)
+
+    :param obj: Object to get the class name from
+    :param args: Optional tuples of (param_name, value) which will ensure ordering during format
+    :param kwargs: Other keyword args to populate with
+    :return: String which represents the object
+    """
+    items = args + tuple(kwargs.items())
+    inner = ", ".join("{}={!r}".format(k, v) for k, v in items)
+    return "{}({})".format(obj.__class__.__name__, inner)
+
+
 class Stopwatch(object):
     def __init__(self):
         self._t_start = 0

--- a/blatann/utils/__init__.py
+++ b/blatann/utils/__init__.py
@@ -1,4 +1,5 @@
 import time
+import threading
 import logging
 import sys
 from blatann.utils import _threading
@@ -69,3 +70,24 @@ class Stopwatch(object):
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.stop()
         return self
+
+
+class SynchronousMonotonicCounter(object):
+    """
+    Utility class which implements a thread-safe monotonic counter
+    """
+    def __init__(self, start_value=0):
+        self._lock = threading.Lock()
+        self._counter = start_value
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        return self.next()
+
+    def next(self):
+        with self._lock:
+            value = self._counter
+            self._counter += 1
+        return value

--- a/tests/integrated/test_gatt_writes.py
+++ b/tests/integrated/test_gatt_writes.py
@@ -1,0 +1,141 @@
+import math
+import unittest
+import time
+import random
+
+from blatann import BleDevice
+from blatann.event_args import WriteEventArgs
+from blatann.gap.advertise_data import AdvertisingData
+from blatann.gatt.gattc import GattcCharacteristic
+from blatann.gatt.gatts import GattsCharacteristicProperties, GattsCharacteristic
+from blatann.peer import conn_interval_range, ConnectionParameters, Client, Peripheral
+from blatann.utils import Stopwatch
+from blatann.uuid import Uuid128
+
+from tests.integrated.base import BlatannTestCase, TestParams, long_running
+
+
+class _PeriphConn(object):
+    def __init__(self):
+        self.peer: Client = None
+        self.write_char: GattsCharacteristic = None
+        self.write_no_resp_char: GattsCharacteristic = None
+
+
+class _CentralConn(object):
+    def __init__(self):
+        self.peer: Peripheral = None
+        self.write_char: GattcCharacteristic = None
+        self.write_no_resp_char: GattcCharacteristic = None
+
+    @property
+    def db(self):
+        return self.peer.database
+
+
+class TestGattWrites(BlatannTestCase):
+    periph_conn = _PeriphConn()
+    central_conn = _CentralConn()
+    periph: BleDevice
+    central: BleDevice
+    write_size: int
+    service_uuid: Uuid128
+    write_char_uuid: Uuid128
+    write_no_resp_char_uuid: Uuid128
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        super(TestGattWrites, cls).setUpClass()
+        cls.periph = cls.dev1
+        cls.central = cls.dev2
+        cls.write_size = cls.periph.max_mtu_size-3
+        cls.service_uuid = Uuid128("00112233-4455-6677-8899-aabbccddeeff")
+        cls.write_char_uuid = cls.service_uuid.new_uuid_from_base(0x0000)
+        cls.write_no_resp_char_uuid = cls.service_uuid.new_uuid_from_base(0x0001)
+        cls._setup_database()
+        cls._setup_connection()
+
+    @classmethod
+    def _setup_database(cls):
+        w_props = GattsCharacteristicProperties(read=False, write=True,
+                                                max_length=cls.write_size, variable_length=True)
+        w_no_resp_props = GattsCharacteristicProperties(read=False, write_no_response=True,
+                                                        max_length=cls.write_size, variable_length=True)
+        svc = cls.periph.database.add_service(cls.service_uuid)
+        cls.periph_conn.write_char = svc.add_characteristic(cls.write_char_uuid, w_props)
+        cls.periph_conn.write_no_resp_char = svc.add_characteristic(cls.write_no_resp_char_uuid, w_no_resp_props)
+
+    @classmethod
+    def _setup_connection(cls):
+        cls.periph.client.preferred_mtu_size = cls.periph.max_mtu_size
+        conn_params = ConnectionParameters(conn_interval_range.min, conn_interval_range.min, 4000)
+
+        cls.periph.set_default_peripheral_connection_params(conn_params.min_conn_interval_ms,
+                                                            conn_params.max_conn_interval_ms,
+                                                            conn_params.conn_sup_timeout_ms)
+        cls.periph.advertiser.set_advertise_data(AdvertisingData(flags=0x06, local_name="Blatann Test"))
+        adv_addr = cls.periph.address
+
+        # Start advertising, then initiate connection from central.
+        # Once central reports its connected wait for the peripheral to be connected before continuing
+        waitable = cls.periph.advertiser.start(timeout_sec=30)
+        cls.central_conn.peer = cls.central.connect(adv_addr, conn_params).wait(10)
+        cls.periph_conn.peer = waitable.wait(10)
+
+        cls.central_conn.peer.exchange_mtu(cls.central.max_mtu_size).wait(10)
+        cls.central_conn.peer.update_data_length().wait(10)
+        cls.central_conn.peer.discover_services().wait(10)
+        cls.central_conn.write_char = cls.central_conn.db.find_characteristic(cls.write_char_uuid)
+        cls.central_conn.write_no_resp_char = cls.central_conn.db.find_characteristic(cls.write_no_resp_char_uuid)
+
+    def setUp(self) -> None:
+        # Verify connection was setup correctly before executing any tests
+        self.assertIsNotNone(self.central_conn.peer)
+        self.assertIsNotNone(self.periph_conn.peer)
+
+        self.assertIsNotNone(self.central_conn.write_char)
+        self.assertIsNotNone(self.central_conn.write_no_resp_char)
+        self.assertTrue(self.central_conn.write_char.writable)
+        self.assertTrue(self.central_conn.write_no_resp_char.writable_without_response)
+
+    def _run_throughput_test(self, periph_char: GattsCharacteristic, central_char: GattcCharacteristic):
+        # Queue up 20k of data, track the time it takes to send
+        periph_stopwatch = Stopwatch()
+        central_stopwatch = Stopwatch()
+
+        n_packets = math.ceil(20000 / self.write_size)
+        bytes_to_send = n_packets * self.write_size
+        bytes_sent = 0
+        bytes_received = [0]
+        packets_received = [0]
+
+        data = bytes(random.randint(0, 255) for _ in range(self.write_size))
+
+        def on_write_received(char: GattsCharacteristic, event_data: WriteEventArgs):
+            if periph_stopwatch.is_running:
+                periph_stopwatch.mark()
+            else:
+                periph_stopwatch.start()
+            packets_received[0] += 1
+            bytes_received[0] += len(event_data.value)
+
+        write_func = central_char.write if central_char.writable else central_char.write_without_response
+
+        with periph_char.on_write.register(on_write_received):
+            central_stopwatch.start()
+            while bytes_sent < bytes_to_send:
+                waitable = write_func(data)
+                bytes_sent += self.write_size
+            waitable.wait(60)
+            central_stopwatch.stop()
+            time.sleep(0.5)
+
+        self.logger.info(f"{bytes_sent} bytes sent in {periph_stopwatch.elapsed:.3f}s/{central_stopwatch.elapsed:.3f}. "
+                         f"Bytes Received: {bytes_received[0]}, Packets: {packets_received[0]}")
+        self.logger.info(f"Throughput: {bytes_sent/central_stopwatch.elapsed/1024.0:.3f}kB/s")
+
+    def test_write_with_response_throughput(self):
+        self._run_throughput_test(self.periph_conn.write_char, self.central_conn.write_char)
+
+    def test_write_without_response_throughput(self):
+        self._run_throughput_test(self.periph_conn.write_no_resp_char, self.central_conn.write_no_resp_char)


### PR DESCRIPTION
Includes a test suite which demos the throughput of using write with responses vs without, using 247 MTU/251 Data Length. In general the throughput doubles without responses (15 kB/s vs 7.5 kB/s, using nRF52840 USB dongles)

Other changes:
- Updates the default connection event length to support the max data length (251)
- Adds method to trigger data length update procedure on a connection
- Adds utility class `SynchronousMonotonicCounter` to remove some duplicate logic

Fixes #37 