### PR TITLE
Security fixes

### DIFF
--- a/blatann/gap/scanning.py
+++ b/blatann/gap/scanning.py
@@ -37,6 +37,10 @@ class ScanParameters(nrf_types.BLEGapScanParams):
         if window_ms > interval_ms:
             raise ValueError(f"Window cannot be greater than the interval (window: {window_ms}, interval: {interval_ms}")
 
+    def __repr__(self):
+        return f"ScanParameters(window: {self.window_ms}ms, interval: {self.interval_ms}ms, " \
+               f"timeout: {self.timeout_s}s, active: {self.active})"
+
 
 class Scanner(object):
     def __init__(self, ble_device):

--- a/blatann/nrf/nrf_driver.py
+++ b/blatann/nrf/nrf_driver.py
@@ -431,28 +431,11 @@ class NrfDriver(object):
 
     @NordicSemiErrorCheck
     @wrapt.synchronized(api_lock)
-    def ble_gap_encrypt(self, conn_handle, ediv, rand, ltk, lesc, auth):
-        # TODO: Clean up
-        # assert isinstance(sec_params, (BLEGapSecParams, NoneType)), 'Invalid argument type'
-        # assert isinstance(sec_keyset, BLEGapSecKeyset), 'Invalid argument type'
-        # print 'ediv %r' % master_id.ediv
-        # print 'rand %r' % util.uint8_array_to_list(master_id.rand, 8)
-        # print 'ltk  %r' % util.uint8_array_to_list(enc_info.ltk, enc_info.ltk_len)
-        # print 'len  %r' % enc_info.ltk_len
-        # print 'lesc %r' % enc_info.lesc
-        # print 'auth %r' % enc_info.auth
+    def ble_gap_encrypt(self, conn_handle, master_id, enc_info):
+        assert isinstance(master_id, BLEGapMasterId)
+        assert isinstance(enc_info, BLEGapEncryptInfo)
 
-        rand_arr = util.list_to_uint8_array(rand)
-        ltk_arr = util.list_to_uint8_array(ltk)
-        master_id = driver.ble_gap_master_id_t()
-        master_id.ediv = ediv
-        master_id.rand = rand_arr.cast()
-        enc_info = driver.ble_gap_enc_info_t()
-        enc_info.ltk_len = len(ltk)
-        enc_info.ltk = ltk_arr.cast()
-        enc_info.lesc = lesc
-        enc_info.auth = auth
-        return driver.sd_ble_gap_encrypt(self.rpc_adapter, conn_handle, master_id, enc_info)
+        return driver.sd_ble_gap_encrypt(self.rpc_adapter, conn_handle, master_id.to_c(), enc_info.to_c())
 
     @NordicSemiErrorCheck
     @wrapt.synchronized(api_lock)

--- a/blatann/nrf/nrf_driver.py
+++ b/blatann/nrf/nrf_driver.py
@@ -77,7 +77,7 @@ def NordicSemiErrorCheck(wrapped=None, expected=driver.NRF_SUCCESS):
                 err_string = 'Error code: {}'.format(NrfError(err_code))
             except ValueError:
                 err_string = 'Error code: 0x{:04x}, {}'.format(err_code, err_code)
-            raise NordicSemiException('Failed to {}. {}'.format(wrapped.__name__, err_string))
+            raise NordicSemiException('Failed to {}. {}'.format(wrapped.__name__, err_string), err_code)
         return result
 
     return wrapper(wrapped)

--- a/blatann/nrf/nrf_events/__init__.py
+++ b/blatann/nrf/nrf_events/__init__.py
@@ -27,8 +27,7 @@ _event_classes = [
     GapEvtPasskeyDisplay,
     GapEvtSecInfoRequest,
     GapEvtLescDhKeyRequest,
-    # TODO: (not all listed)
-    # driver.BLE_GAP_EVT_SEC_REQUEST,
+    GapEvtSecRequest,
 
     # Gattc
     GattcEvtPrimaryServiceDiscoveryResponse,

--- a/blatann/nrf/nrf_events/smp_events.py
+++ b/blatann/nrf/nrf_events/smp_events.py
@@ -1,5 +1,3 @@
-from enum import IntEnum
-
 from blatann.nrf.nrf_types import *
 from blatann.nrf.nrf_dll_load import driver
 import blatann.nrf.nrf_driver_types as util
@@ -28,11 +26,7 @@ class GapEvtConnSecUpdate(GapEvtSec):
                    encr_key_size=conn_sec.encr_key_size)
 
     def __repr__(self):
-        return "{}(conn_handle={!r}, sec_mode={!r}, sec_level={!r}, encr_key_size={!r})".format(self.__class__.__name__,
-                                                                                                self.conn_handle,
-                                                                                                self.sec_mode,
-                                                                                                self.sec_level,
-                                                                                                self.encr_key_size)
+        return self._repr_format(sec_mode=self.sec_mode, sec_level=self.sec_level, encr_key_size=self.encr_key_size)
 
 
 class GapEvtSecInfoRequest(GapEvtSec):
@@ -56,9 +50,33 @@ class GapEvtSecInfoRequest(GapEvtSec):
         return cls(conn_handle, peer_addr, master_id, sec_info.enc_info, sec_info.id_info, sec_info.sign_info)
 
     def __repr__(self):
-        return "{}(conn_handle={!r}, peer_addr={!r}, master_id={!r}, enc: {!r}, id: {!r}, sign: {!r})".format(
-            self.__class__.__name__, self.conn_handle, self.peer_addr, self.master_id,
-            self.enc_info, self.id_info, self.sign_info)
+        return self._repr_format(peer_addr=self.peer_addr, master_id=self.master_id, enc=self.enc_info,
+                                 id=self.id_info, sign=self.sign_info)
+
+
+class GapEvtSecRequest(GapEvtSec):
+    evt_id = driver.BLE_GAP_EVT_SEC_REQUEST
+
+    def __init__(self, conn_handle, bond, mitm, lesc, keypress):
+        super(GapEvtSecRequest, self).__init__(conn_handle)
+        self.bond = bond
+        self.mitm = mitm
+        self.lesc = lesc
+        self.keypress = keypress
+
+    @classmethod
+    def from_c(cls, event):
+        conn_handle = event.evt.gap_evt.conn_handle
+        sec_req = event.evt.gap_evt.params.sec_request
+        bond = bool(sec_req.bond)
+        mitm = bool(sec_req.mitm)
+        lesc = bool(sec_req.lesc)
+        keypress = bool(sec_req.keypress)
+
+        return cls(conn_handle, bond, mitm, lesc, keypress)
+
+    def __repr__(self):
+        return self._repr_format(bond=self.bond, mitm=self.mitm, lesc=self.lesc, keypress=self.keypress)
 
 
 class GapEvtSecParamsRequest(GapEvtSec):
@@ -75,8 +93,7 @@ class GapEvtSecParamsRequest(GapEvtSec):
                    sec_params=BLEGapSecParams.from_c(sec_params))
 
     def __repr__(self):
-        return "{}(conn_handle={!r}, sec_params={!r})".format(self.__class__.__name__, self.conn_handle,
-                                                              self.sec_params)
+        return self._repr_format(sec_params=self.sec_params)
 
 
 class GapEvtAuthKeyRequest(GapEvtSec):
@@ -93,7 +110,7 @@ class GapEvtAuthKeyRequest(GapEvtSec):
                    key_type=BLEGapAuthKeyType(auth_key_request.key_type))
 
     def __repr__(self):
-        return "{}(conn_handle={!r}, key_type={!r})".format(self.__class__.__name__, self.conn_handle, self.key_type)
+        return self._repr_format(key_type=self.key_type)
 
 
 class GapEvtAuthStatus(GapEvtSec):
@@ -122,12 +139,9 @@ class GapEvtAuthStatus(GapEvtSec):
                    kdist_peer=BLEGapSecKeyDist.from_c(auth_status.kdist_peer))
 
     def __repr__(self):
-        return "{}(conn_handle={!r}, auth_status={!r}, error_src={!r}, " \
-               "bonded={!r}, sm1_levels={!r}, sm2_levels={!r}, " \
-               "kdist_own={!r}, kdist_peer={!r})".format(self.__class__.__name__, self.conn_handle, self.auth_status,
-                                                         self.error_src, self.bonded,
-                                                         self.sm1_levels, self.sm2_levels, self.kdist_own,
-                                                         self.kdist_peer)
+        return self._repr_format(auth_status=self.auth_status, error_src=self.error_src, bonded=self.bonded,
+                                 sm1_levels=self.sm1_levels, sm2_levels=self.sm2_levels,
+                                 kdist_own=self.kdist_own, kdist_peer=self.kdist_peer)
 
 
 class GapEvtPasskeyDisplay(GapEvtSec):
@@ -148,9 +162,7 @@ class GapEvtPasskeyDisplay(GapEvtSec):
                    match_request=match_request)
 
     def __repr__(self):
-        return "{}(conn_handle={!r}, passkey={!r}, match_request={!r})".format(self.__class__.__name__,
-                                                                               self.conn_handle, self.passkey,
-                                                                               self.match_request)
+        return self._repr_format(passkey=self.passkey, match_request=self.match_request)
 
 
 class GapEvtLescDhKeyRequest(GapEvtSec):
@@ -171,5 +183,4 @@ class GapEvtLescDhKeyRequest(GapEvtSec):
                    oob_required=oob_required)
 
     def __repr__(self):
-        return "{}(conn_handle={!r}, remote key: {!r}, oob? {}".format(self.__class__.__name__, self.conn_handle,
-                                                                       self.remote_public_key, self.oob_required)
+        return self._repr_format(remote_key=self.remote_public_key, oob=self.oob_required)

--- a/blatann/nrf/nrf_types/enums.py
+++ b/blatann/nrf/nrf_types/enums.py
@@ -73,19 +73,26 @@ class NrfError(Enum):
     # soc_rand_not_enough_values = driver.NRF_ERROR_SOC_RAND_NOT_ENOUGH_VALUES
     # soc_ppi_invalid_channel = driver.NRF_ERROR_SOC_PPI_INVALID_CHANNEL
     # soc_ppi_invalid_group = driver.NRF_ERROR_SOC_PPI_INVALID_GROUP
-    # ble_not_enabled = driver.BLE_ERROR_NOT_ENABLED
-    # ble_invalid_conn_handle = driver.BLE_ERROR_INVALID_CONN_HANDLE
-    # ble_invalid_attr_handle = driver.BLE_ERROR_INVALID_ATTR_HANDLE
-    # ble_invalid_role = driver.BLE_ERROR_INVALID_ROLE
-    # ble_gap_uuid_list_mismatch = driver.BLE_ERROR_GAP_UUID_LIST_MISMATCH
-    # ble_gap_discoverable_with_whitelist = driver.BLE_ERROR_GAP_DISCOVERABLE_WITH_WHITELIST
-    # ble_gap_invalid_ble_addr = driver.BLE_ERROR_GAP_INVALID_BLE_ADDR
-    # ble_gap_whitelist_in_use = driver.BLE_ERROR_GAP_WHITELIST_IN_USE
-    # ble_gap_device_identities_in_use = driver.BLE_ERROR_GAP_DEVICE_IDENTITIES_IN_USE
-    # ble_gap_device_identities_duplicate = driver.BLE_ERROR_GAP_DEVICE_IDENTITIES_DUPLICATE
-    # ble_gatts_invalid_attr_type = driver.BLE_ERROR_GATTS_INVALID_ATTR_TYPE
-    # ble_gatts_sys_attr_missing = driver.BLE_ERROR_GATTS_SYS_ATTR_MISSING
-    # ble_gattc_proc_not_permitted = driver.BLE_ERROR_GATTC_PROC_NOT_PERMITTED
+
+    # Values copied from header files, should replace with driver values if ever exposed from there
+    ble_not_enabled = 0x3001
+    ble_invalid_conn_handle = 0x3002
+    ble_invalid_attr_handle = 0x3003
+    ble_invalid_adv_handle = 0x3004
+    ble_invalid_role = 0x3005
+    ble_blocked_by_other_links = 0x3006
+
+    ble_gap_uuid_list_mismatch = 0x3200
+    ble_gap_discoverable_with_whitelist = 0x3201
+    ble_gap_invalid_ble_addr = 0x3202
+    ble_gap_whitelist_in_use = 0x3203
+    ble_gap_device_identities_in_use = 0x3204
+    ble_gap_device_identities_duplicate = 0x3205
+
+    ble_gattc_proc_not_permitted = 0x3300
+
+    ble_gatts_invalid_attr_type = 0x3400
+    ble_gatts_sys_attr_missing = 0x3401
 
 
 """


### PR DESCRIPTION
- Fixes issue initiating encryption with an already-bonded device as a central
- Adds support for handling peer-initiated security. Currently automatically handled
- Adds BLE error codes to the `NrfError` enum