### PR TITLE
Security Manager improvements

### DIFF
--- a/blatann/device.py
+++ b/blatann/device.py
@@ -232,10 +232,16 @@ class BleDevice(NrfDriverObserver):
         if self.connecting_peripheral is not None:
             raise exceptions.InvalidStateException("Cannot initiate a new connection while connecting to another")
 
+        # Try finding the peer's name in the scan report
+        name = ""
+        scan_report = self.scanner.scan_report.get_report_for_peer(peer_address)
+        if scan_report:
+            name = scan_report.advertise_data.local_name
+
         if not connection_params:
             connection_params = self._default_conn_params
 
-        self.connecting_peripheral = peer.Peripheral(self, peer_address, connection_params)
+        self.connecting_peripheral = peer.Peripheral(self, peer_address, connection_params, self._default_security_params, name)
         periph_connection_waitable = PeripheralConnectionWaitable(self, self.connecting_peripheral)
         self.ble_driver.ble_gap_connect(peer_address, conn_params=connection_params,
                                         conn_cfg_tag=self._default_conn_config.conn_tag)

--- a/blatann/event_args.py
+++ b/blatann/event_args.py
@@ -190,6 +190,9 @@ class PeripheralSecurityRequestEventArgs(EventArgs):
 
 
 class PairingRejectedReason(Enum):
+    """
+    Reason why pairing was rejected
+    """
     non_bonded_central_request = auto()
     non_bonded_peripheral_request = auto()
     bonded_peripheral_request = auto()
@@ -197,9 +200,10 @@ class PairingRejectedReason(Enum):
     user_rejected = auto()
 
 
-
-
 class PairingRejectedEventArgs(EventArgs):
+    """
+    Event arguments for when a pairing request was rejected locally
+    """
     def __init__(self, reason: PairingRejectedReason):
         self.reason = reason
 

--- a/blatann/event_type.py
+++ b/blatann/event_type.py
@@ -60,6 +60,11 @@ class EventSource(Event):
         super(EventSource, self).__init__(name)
         self._logger = logger
 
+    @property
+    def has_handlers(self):
+        with self._handler_lock:
+            return bool(self._handlers)
+
     def clear_handlers(self):
         with self._handler_lock:
             self._handlers = []

--- a/blatann/examples/central.py
+++ b/blatann/examples/central.py
@@ -52,9 +52,8 @@ def on_peripheral_security_request(peer, event_args):
     For example, to reject new pairing requests but allow already-bonded
     devices to enable encryption, one could use the event_args.is_bonded_device flag to accept or reject the request.
 
-    This handler is optional. If not provided the default action is to accept all security requests and
-    initiate pairing (or encryption if the peripheral is already bonded),
-    unless the reject_pairing_requests parameter is set.
+    This handler is optional. If not provided the SecurityParameters.reject_pairing_requests parameter will
+    determine the action to take.
 
     :param peer: The peer that requested security
     :type peer: blatann.peer.Peer
@@ -122,7 +121,7 @@ def main(serial_port):
 
     peer.set_connection_parameters(100, 120, 6000)  # Discovery complete, go to a longer connection interval
 
-    # Wait up to 60 seconds for the pairing process
+    # Wait up to 60 seconds for the pairing process, if the link is not secured yet
     if peer.security.security_level == smp.SecurityLevel.OPEN:
         peer.security.pair().wait(60)
 

--- a/blatann/examples/central.py
+++ b/blatann/examples/central.py
@@ -43,6 +43,39 @@ def on_passkey_entry(peer, passkey_event_args):
     passkey_event_args.resolve(passkey)
 
 
+def on_peripheral_security_request(peer, event_args):
+    """
+    Handler for peripheral-initiated security requests. This is useful in the case that the
+    application wants to override the default response to peripheral-initiated security requests
+    based on parameters, the peer, etc.
+
+    For example, to reject new pairing requests but allow already-bonded
+    devices to enable encryption, one could use the event_args.is_bonded_device flag to accept or reject the request.
+
+    This handler is optional. If not provided the default action is to accept all security requests and
+    initiate pairing (or encryption if the peripheral is already bonded),
+    unless the reject_pairing_requests parameter is set.
+
+    :param peer: The peer that requested security
+    :type peer: blatann.peer.Peer
+    :param event_args: The event arguments
+    :type event_args: blatann.event_args.PeripheralSecurityRequestEventArgs
+    """
+    logger.info("{} Peripheral requested security -- bond: {}, mitm: {}, lesc: {}, keypress: {}".format(
+        "Already-Bonded" if event_args.is_bonded_device else "Non-bonded",
+        event_args.bond, event_args.mitm, event_args.lesc, event_args.keypress
+    ))
+    # At this point check the security parameters and accept, reject, or force re-pair depending on your security needs
+    # For this demo, match the requested parameters (not required) and accept
+    peer.security.security_params.bond = event_args.bond
+    peer.security.security_params.passcode_pairing = event_args.mitm
+    peer.security.security_params.lesc_pairing = event_args.lesc
+    event_args.accept()
+    # Other options include
+    #   event_args.reject()
+    #   event_args.force_repair()
+
+
 def main(serial_port):
     # Set the target to the peripheral's advertised name
     target_device_name = constants.PERIPHERAL_NAME
@@ -76,6 +109,8 @@ def main(serial_port):
                                       bond=False, out_of_band=False)
     # Register the callback for when a passkey needs to be entered by the user
     peer.security.on_passkey_required.register(on_passkey_entry)
+    # Register the callback for if a peripheral requests security
+    peer.security.on_peripheral_security_request.register(on_peripheral_security_request)
 
     # Wait up to 10 seconds for service discovery to complete
     _, event_args = peer.discover_services().wait(10, exception_on_timeout=False)
@@ -88,7 +123,8 @@ def main(serial_port):
     peer.set_connection_parameters(100, 120, 6000)  # Discovery complete, go to a longer connection interval
 
     # Wait up to 60 seconds for the pairing process
-    peer.security.pair().wait(60)
+    if peer.security.security_level == smp.SecurityLevel.OPEN:
+        peer.security.pair().wait(60)
 
     # Find the counting characteristic
     counting_char = peer.database.find_characteristic(constants.COUNTING_CHAR_UUID)
@@ -128,4 +164,4 @@ def main(serial_port):
 
 
 if __name__ == '__main__':
-    main("COM9")
+    main("COM11")

--- a/blatann/gap/__init__.py
+++ b/blatann/gap/__init__.py
@@ -1,5 +1,6 @@
 from blatann.nrf.nrf_types import BLEHci as _BLEHci
-from blatann.gap.smp import SecurityStatus, IoCapabilities, AuthenticationKeyType, SecurityParameters
+from blatann.gap.smp import (SecurityStatus, IoCapabilities, AuthenticationKeyType,
+                             SecurityParameters, PairingPolicy, SecurityLevel)
 from blatann.gap.scanning import ScanParameters
 from blatann.gap.advertising import AdvertisingData, AdvertisingFlags
 

--- a/blatann/gap/advertise_data.py
+++ b/blatann/gap/advertise_data.py
@@ -1,5 +1,5 @@
 import time
-from typing import Iterable, List, Dict, Union
+from typing import Iterable, List, Dict, Union, Optional
 import logging
 from blatann.nrf import nrf_types
 from blatann import uuid, exceptions
@@ -316,6 +316,9 @@ class ScanReportCollection(object):
         :rtype: list of ScanReport
         """
         return self._all_scans[:]
+
+    def get_report_for_peer(self, peer_addr) -> Optional[ScanReport]:
+        return self._scans_by_peer_address.get(peer_addr)
 
     def clear(self):
         """

--- a/blatann/gap/bond_db.py
+++ b/blatann/gap/bond_db.py
@@ -1,3 +1,7 @@
+import typing
+
+if typing.TYPE_CHECKING:
+    from blatann.peer import PeerAddress
 
 
 class BondingData(object):
@@ -14,25 +18,23 @@ class BondingData(object):
 class BondDbEntry(object):
     def __init__(self, entry_id=0):
         self.id = entry_id
-        self.peer_addr = None
-        self.peer_is_client = None
-        self.bonding_data = None  # type: BondingData
+        self.peer_addr: PeerAddress = None
+        self.peer_is_client: bool = False
+        self.bonding_data: BondingData = None
+        self.name = ""
 
 
 class BondDatabase(object):
-    def create(self):
-        """
-        :rtype: BondDbEntry
-        """
+    def create(self) -> BondDbEntry:
         raise NotImplementedError()
 
-    def add(self, db_entry):
+    def add(self, db_entry: BondDbEntry):
         raise NotImplementedError()
 
-    def update(self, db_entry):
+    def update(self, db_entry: BondDbEntry):
         raise NotImplementedError()
 
-    def delete(self, db_entry):
+    def delete(self, db_entry: BondDbEntry):
         raise NotImplementedError()
 
     def delete_all(self):

--- a/blatann/gap/default_bond_db.py
+++ b/blatann/gap/default_bond_db.py
@@ -1,6 +1,8 @@
 import os
 import logging
 import pickle
+from typing import List
+
 import blatann
 from blatann.gap.bond_db import BondDatabase, BondDbEntry, BondDatabaseLoader
 
@@ -38,7 +40,7 @@ class DefaultBondDatabaseLoader(BondDatabaseLoader):
 
 class DefaultBondDatabase(BondDatabase):
     def __init__(self):
-        self._records = []  # type: list[BondDbEntry]
+        self._records: List[BondDbEntry] = []
         self.current_id = 0
 
     def __iter__(self):

--- a/blatann/nrf/nrf_types/smp.py
+++ b/blatann/nrf/nrf_types/smp.py
@@ -248,7 +248,7 @@ class BLEGapIdKey(object):
     def __repr__(self):
         if not self.irk:
             return ""
-        return "irk: {}, peer: {}".format(binascii.hexlify(self.key).decode("ascii"), self.peer_addr)
+        return "irk: {}, peer: {}".format(binascii.hexlify(self.irk).decode("ascii"), self.peer_addr)
 
 
 class BLEGapPublicKey(object):

--- a/blatann/peer.py
+++ b/blatann/peer.py
@@ -100,12 +100,14 @@ class Peer(object):
     NOTIFICATION_INDICATION_OVERHEAD_BYTES = 3
 
     def __init__(self, ble_device, role, connection_params=DEFAULT_CONNECTION_PARAMS,
-                 security_params=DEFAULT_SECURITY_PARAMS):
+                 security_params=DEFAULT_SECURITY_PARAMS,
+                 name=""):
         """
         :type ble_device: blatann.device.BleDevice
         """
         self._ble_device = ble_device
         self._role = role
+        self._name = name
         self._preferred_connection_params = connection_params
         self._current_connection_params = ActiveConnectionParameters(connection_params)
         self.conn_handle = BLE_CONN_HANDLE_INVALID
@@ -131,6 +133,23 @@ class Peer(object):
     """
     Properties
     """
+
+    @property
+    def name(self) -> str:
+        """
+        The name of the peer, if known
+
+        .. note:: For central peers this name is unknown unless set by the setter below.
+           For peripheral peers the name is defaulted to the one found in the advertising payload, if any.
+        """
+        return self._name
+
+    @name.setter
+    def name(self, name: str):
+        """
+        Sets the name of the peer. This is
+        """
+        self._name = name
 
     @property
     def connected(self):
@@ -227,7 +246,6 @@ class Peer(object):
         :return: The database instance
         """
         return self._db
-
 
     """
     Events
@@ -507,9 +525,10 @@ class Peripheral(Peer):
     """
     def __init__(self, ble_device, peer_address,
                  connection_params=DEFAULT_CONNECTION_PARAMS,
-                 security_params=DEFAULT_SECURITY_PARAMS):
+                 security_params=DEFAULT_SECURITY_PARAMS,
+                 name=""):
         super(Peripheral, self).__init__(ble_device, nrf_events.BLEGapRoles.central, connection_params,
-                                         security_params)
+                                         security_params, name)
         self.peer_address = peer_address
         self.connection_state = PeerState.CONNECTING
 
@@ -520,9 +539,10 @@ class Client(Peer):
     """
     def __init__(self, ble_device,
                  connection_params=DEFAULT_CONNECTION_PARAMS,
-                 security_params=DEFAULT_SECURITY_PARAMS):
+                 security_params=DEFAULT_SECURITY_PARAMS,
+                 name=""):
         super(Client, self).__init__(ble_device, nrf_events.BLEGapRoles.periph, connection_params,
-                                     security_params)
+                                     security_params, name)
         self._first_connection = True
 
     def peer_connected(self, conn_handle, peer_address, connection_params):
@@ -531,4 +551,5 @@ class Client(Peer):
             self._db = gattc.GattcDatabase(self._ble_device, self)
             self._discoverer = service_discovery.DatabaseDiscoverer(self._ble_device, self)
         self._first_connection = False
+        self._name = ""
         super(Client, self).peer_connected(conn_handle, peer_address, connection_params)

--- a/blatann/peer.py
+++ b/blatann/peer.py
@@ -505,8 +505,11 @@ class Peripheral(Peer):
     """
     Object which represents a BLE-connected device that is acting as a peripheral/server (local device is client/central)
     """
-    def __init__(self, ble_device, peer_address, connection_params=DEFAULT_CONNECTION_PARAMS):
-        super(Peripheral, self).__init__(ble_device, nrf_events.BLEGapRoles.central, connection_params)
+    def __init__(self, ble_device, peer_address,
+                 connection_params=DEFAULT_CONNECTION_PARAMS,
+                 security_params=DEFAULT_SECURITY_PARAMS):
+        super(Peripheral, self).__init__(ble_device, nrf_events.BLEGapRoles.central, connection_params,
+                                         security_params)
         self.peer_address = peer_address
         self.connection_state = PeerState.CONNECTING
 
@@ -515,8 +518,11 @@ class Client(Peer):
     """
     Object which represents a BLE-connected device that is acting as a client/central (local device is peripheral/server)
     """
-    def __init__(self, ble_device, connection_params=DEFAULT_CONNECTION_PARAMS):
-        super(Client, self).__init__(ble_device, nrf_events.BLEGapRoles.periph, connection_params)
+    def __init__(self, ble_device,
+                 connection_params=DEFAULT_CONNECTION_PARAMS,
+                 security_params=DEFAULT_SECURITY_PARAMS):
+        super(Client, self).__init__(ble_device, nrf_events.BLEGapRoles.periph, connection_params,
+                                     security_params)
         self._first_connection = True
 
     def peer_connected(self, conn_handle, peer_address, connection_params):

--- a/tests/integrated/test_security.py
+++ b/tests/integrated/test_security.py
@@ -1,19 +1,19 @@
+import queue
 import threading
 import time
 import unittest
+from typing import Union
 
-from blatann.gap import SecurityStatus, SecurityLevel
-from blatann.peer import Client, Peripheral, PairingRejectedReason
+from blatann.event_args import PasskeyDisplayEventArgs, PasskeyEntryEventArgs
+
+from blatann.gap import SecurityStatus, SecurityLevel, IoCapabilities, PairingPolicy, SecurityParameters
+from blatann.peer import Client, Peripheral, PairingRejectedReason, DEFAULT_SECURITY_PARAMS
 
 from blatann import BleDevice
-from blatann.gap.advertising import AdvertisingMode
 from blatann.gap.advertise_data import AdvertisingData, AdvertisingFlags, AdvertisingPacketType
-from blatann.gap.scanning import MIN_SCAN_WINDOW_MS, MIN_SCAN_INTERVAL_MS, ScanParameters
-from blatann.uuid import Uuid16
-from blatann.utils import Stopwatch
 from blatann.waitables import EventWaitable
 
-from tests.integrated.base import BlatannTestCase, TestParams, long_running, EventCollector
+from tests.integrated.base import BlatannTestCase, TestParams, long_running
 
 
 class TestSecurity(BlatannTestCase):
@@ -46,11 +46,23 @@ class TestSecurity(BlatannTestCase):
             self.peer_per.disconnect().wait(5)
             self.peer_per = None
 
-    def test_nonbonded_devices_peripheral_rejects_by_default(self):
+    def _set_security_parameters(self, passcode_pairing: bool,
+                            io_capabilities: IoCapabilities,
+                            bond: bool,
+                            reject_pairing_requests: Union[bool, PairingPolicy] = False,
+                            lesc_pairing: bool = False):
+        security_params1 = SecurityParameters(passcode_pairing, io_capabilities, bond, False, reject_pairing_requests, lesc_pairing)
+        security_params2 = SecurityParameters(passcode_pairing, io_capabilities, bond, False, reject_pairing_requests, lesc_pairing)
+        self.peer_per.security.security_params = security_params1
+        self.peer_cen.security.security_params = security_params2
+
+    def test_nonbonded_devices_rejects_by_default(self):
         self.periph_dev.clear_bonding_data()
         self.central_dev.clear_bonding_data()
 
         self._connect()
+        self.peer_per.security.security_params = DEFAULT_SECURITY_PARAMS
+        self.peer_cen.security.security_params = DEFAULT_SECURITY_PARAMS
 
         self.assertFalse(self.peer_per.is_previously_bonded)
         self.assertFalse(self.peer_cen.is_previously_bonded)
@@ -75,3 +87,96 @@ class TestSecurity(BlatannTestCase):
         self.assertEqual(SecurityLevel.OPEN, result.security_level)
         self.assertEqual(PairingRejectedReason.non_bonded_peripheral_request, rejection.reason)
 
+    def test_bonding_no_mitm_happy_path(self):
+        self.periph_dev.clear_bonding_data()
+        self.central_dev.clear_bonding_data()
+
+        self._connect()
+
+        self.assertFalse(self.peer_per.is_previously_bonded)
+        self.assertFalse(self.peer_cen.is_previously_bonded)
+
+        self._set_security_parameters(False, IoCapabilities.NONE, True, False, True)
+
+        _, result = self.peer_per.security.pair().wait(10)
+
+        self.assertEqual(SecurityStatus.success, result.status)
+        self.assertEqual(SecurityLevel.JUST_WORKS, self.peer_per.security.security_level)
+        self.assertEqual(SecurityLevel.JUST_WORKS, self.peer_cen.security.security_level)
+
+    def test_bonding_passcode_match_happy_path(self):
+        self.periph_dev.clear_bonding_data()
+        self.central_dev.clear_bonding_data()
+
+        self._connect()
+
+        self.assertFalse(self.peer_per.is_previously_bonded)
+        self.assertFalse(self.peer_cen.is_previously_bonded)
+
+        self._set_security_parameters(True, IoCapabilities.DISPLAY_YESNO, True, False, True)
+        per_passcode_q = queue.Queue()
+        cen_passcode_q = queue.Queue()
+        per_event = threading.Event()
+        cen_event = threading.Event()
+
+        def on_display_request(peer, event_args: PasskeyDisplayEventArgs):
+            if peer == self.peer_cen:
+                our_q, their_q, event = cen_passcode_q, per_passcode_q, cen_event
+            else:
+                our_q, their_q, event = per_passcode_q, cen_passcode_q, per_event
+
+            event.set()
+            their_q.put(event_args.passkey)
+            passkey = our_q.get()
+
+            if passkey != event_args.passkey:
+                self.logger.error(f"Passkeys did not match! {passkey}/{event_args.passkey}")
+            event_args.match_confirm(passkey == event_args.passkey)
+
+        with self.peer_cen.security.on_passkey_display_required.register(on_display_request):
+            with self.peer_per.security.on_passkey_display_required.register(on_display_request):
+                _, result = self.peer_per.security.pair().wait(10)
+
+        self.assertEqual(SecurityStatus.success, result.status)
+        self.assertEqual(SecurityLevel.LESC_MITM, self.peer_per.security.security_level)
+        self.assertEqual(SecurityLevel.LESC_MITM, self.peer_cen.security.security_level)
+        self.assertTrue(per_event.is_set())
+        self.assertTrue(cen_event.is_set())
+
+    def test_bonding_passkey_entry_happy_path(self):
+        self.periph_dev.clear_bonding_data()
+        self.central_dev.clear_bonding_data()
+
+        self._connect()
+
+        self.assertFalse(self.peer_per.is_previously_bonded)
+        self.assertFalse(self.peer_cen.is_previously_bonded)
+
+        self._set_security_parameters(True, IoCapabilities.DISPLAY_ONLY, True, False, True)
+        self.peer_per.security.security_params.io_capabilities = IoCapabilities.KEYBOARD_DISPLAY
+        passcode_q = queue.Queue()
+        display_event = threading.Event()
+        entry_event = threading.Event()
+
+        def on_display_request(peer, event_args: PasskeyDisplayEventArgs):
+            self.logger.info("Got display request")
+            passcode_q.put(event_args.passkey)
+            display_event.set()
+
+        def on_entry_request(peer, event_args: PasskeyEntryEventArgs):
+            self.logger.info("Got entry request")
+            passkey = passcode_q.get()
+            entry_event.set()
+            event_args.resolve(passkey)
+
+        with self.peer_cen.security.on_passkey_display_required.register(on_display_request):
+            with self.peer_per.security.on_passkey_required.register(on_entry_request):
+                _, result = self.peer_per.security.pair().wait(10)
+
+        self.assertEqual(SecurityStatus.success, result.status)
+        self.assertEqual(SecurityLevel.LESC_MITM, self.peer_per.security.security_level)
+        self.assertEqual(SecurityLevel.LESC_MITM, self.peer_cen.security.security_level)
+        self.assertTrue(display_event.is_set())
+        self.assertTrue(entry_event.is_set())
+
+    # TODO: Add more tests

--- a/tests/integrated/test_security.py
+++ b/tests/integrated/test_security.py
@@ -1,0 +1,77 @@
+import threading
+import time
+import unittest
+
+from blatann.gap import SecurityStatus, SecurityLevel
+from blatann.peer import Client, Peripheral, PairingRejectedReason
+
+from blatann import BleDevice
+from blatann.gap.advertising import AdvertisingMode
+from blatann.gap.advertise_data import AdvertisingData, AdvertisingFlags, AdvertisingPacketType
+from blatann.gap.scanning import MIN_SCAN_WINDOW_MS, MIN_SCAN_INTERVAL_MS, ScanParameters
+from blatann.uuid import Uuid16
+from blatann.utils import Stopwatch
+from blatann.waitables import EventWaitable
+
+from tests.integrated.base import BlatannTestCase, TestParams, long_running, EventCollector
+
+
+class TestSecurity(BlatannTestCase):
+    periph_dev: BleDevice
+    central_dev: BleDevice
+    peer_cen: Client
+    peer_per: Peripheral
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        super(TestSecurity, cls).setUpClass()
+        cls.periph_dev = cls.dev1
+        cls.central_dev = cls.dev2
+        cls.periph_dev.advertiser.set_advertise_data(AdvertisingData(flags=0x06, local_name="BlatannTest"))
+        cls.periph_dev.advertiser.set_default_advertise_params(30, 0)
+        cls.central_dev.scanner.set_default_scan_params(50, 50, 10, False)
+        cls.central_dev.set_default_peripheral_connection_params(10, 10, 4000)
+        cls.peer_cen = cls.periph_dev.client
+
+    def tearDown(self) -> None:
+        self._disconnect()
+
+    def _connect(self):
+        addr = self.periph_dev.address
+        self.periph_dev.advertiser.start()
+        self.peer_per = self.central_dev.connect(addr).wait(5)
+
+    def _disconnect(self):
+        if self.peer_per:
+            self.peer_per.disconnect().wait(5)
+            self.peer_per = None
+
+    def test_nonbonded_devices_peripheral_rejects_by_default(self):
+        self.periph_dev.clear_bonding_data()
+        self.central_dev.clear_bonding_data()
+
+        self._connect()
+
+        self.assertFalse(self.peer_per.is_previously_bonded)
+        self.assertFalse(self.peer_cen.is_previously_bonded)
+
+        # Initiate pairing to peripheral, peripheral should reject
+        reject_waitable = EventWaitable(self.peer_cen.security.on_pairing_request_rejected)
+        _, result = self.peer_per.security.pair().wait(10)
+        _, rejection = reject_waitable.wait(1)
+
+        self.assertEqual(SecurityStatus.pairing_not_supp, result.status)
+        self.assertEqual(SecurityLevel.OPEN, result.security_level)
+        self.assertEqual(PairingRejectedReason.non_bonded_central_request, rejection.reason)
+
+        time.sleep(0.25)
+
+        # Initiate pairing request to central, central should reject
+        reject_waitable = EventWaitable(self.peer_per.security.on_pairing_request_rejected)
+        _, result = self.peer_cen.security.pair().wait(10)
+        _, rejection = reject_waitable.wait(1)
+
+        self.assertEqual(SecurityStatus.pairing_not_supp, result.status)
+        self.assertEqual(SecurityLevel.OPEN, result.security_level)
+        self.assertEqual(PairingRejectedReason.non_bonded_peripheral_request, rejection.reason)
+


### PR DESCRIPTION
Adds numerous improvements to how bonding/pairing is handled for connections

- Adds several events and properties to get details on current connection, update security params, etc.
- Expands the `reject_pairing_requests` field to be a bitfield enum so certain pairing requests can be rejected but others accepted
  - `True`/`False` still accepted and maps to the enum values `reject_all_requests` and `allow_all`, respectively
- adds handling for peripheral-initiated security/pairing requests
- Adds `name` property for peers that is populated from scan reports (for peripheral peers). Can also be set manually. Is used for bonding data as well
- Adds some integration tests around security, much more is needed still
- Adds device-level method to set the default security parameters for all subsequent connections as a central to peripherals