### PR TITLE
adds support for setting parameters in the Generic Access Service

### DIFF
--- a/blatann/bt_sig/assigned_numbers.py
+++ b/blatann/bt_sig/assigned_numbers.py
@@ -1,3 +1,4 @@
+import struct
 from blatann.utils import IntEnumWithDescription
 
 
@@ -202,3 +203,61 @@ class Units(IntEnumWithDescription):
     volume_flow_litre_per_second = 0x27c2, "volume flow (litre per second)"
     volume_litre = 0x2767, "volume (litre)"
     wavenumber_reciprocal_metre = 0x2714, "wavenumber (reciprocal metre)"
+
+
+class Appearance(IntEnumWithDescription):
+    """
+    Appearance enumeration for use with advertising data
+    """
+    unknown = 0, "Unknown"
+    phone = 64, "Phone"
+    computer = 128, "Computer"
+    watch = 192, "Watch"
+    sports_watch = 193, "Sports Watch"
+    clock = 256, "Clock"
+    display = 320, "Display"
+    remote_control = 384, "Remote Control"
+    eye_glasses = 448, "Eye-glasses"
+    tag = 512, "Tag"
+    keyring = 576, "Keyring"
+    media_player = 640, "Media Player"
+    barcode_scanner = 704, "Barcode Scanner"
+    thermometer = 768, "Thermometer"
+    thermometer_ear = 769, "Thermometer: Ear"
+    heart_rate_sensor = 832, "Heart rate Sensor"
+    heart_rate_sensor_heart_rate_belt = 833, "Heart Rate Sensor: Heart Rate Belt"
+    blood_pressure = 896, "Blood Pressure"
+    blood_pressure_arm = 897, "Blood Pressure: Arm"
+    blood_pressure_wrist = 898, "Blood Pressure: Wrist"
+    hid = 960, "Human Interface Device (HID)"
+    hid_keyboard = 961, "Keyboard"
+    hid_mouse = 962, "Mouse"
+    hid_joystick = 963, "Joystick"
+    hid_gamepad = 964, "Gamepadtype)"
+    hid_digitizer = 965, "Digitizer Tablet"
+    hid_card_reader = 966, "Card Reader"
+    hid_digital_pen = 967, "Digital Pen"
+    hid_barcode = 968, "Barcode Scanner"
+    glucose_meter = 1024, "Glucose Meter"
+    running_walking_sensor = 1088, "Running Walking Sensor"
+    running_walking_sensor_in_shoe = 1089, "Running Walking Sensor: In-Shoe"
+    running_walking_sensor_on_shoe = 1090, "Running Walking Sensor: On-Shoe"
+    running_walking_sensor_on_hip = 1091, "Running Walking Sensor: On-Hip"
+    cycling = 1152, "Cycling"
+    cycling_cycling_computer = 1153, "Cycling: Cycling Computer"
+    cycling_speed_sensor = 1154, "Cycling: Speed Sensor"
+    cycling_cadence_sensor = 1155, "Cycling: Cadence Sensor"
+    cycling_power_sensor = 1156, "Cycling: Power Sensor"
+    cycling_speed_cadence_sensor = 1157, "Cycling: Speed and Cadence Sensor"
+    pulse_oximeter = 3136, "Pulse Oximeter"
+    pulse_oximeter_fingertip = 3137, "Fingertip Pulse Oximeter"
+    pulse_oximeter_wrist_worn = 3138, "Wrist Pulse Oximeter"
+    weight_scale = 3200, "Weight Scale"
+    outdoor_sports_act = 5184, "Outdoor Sports Activity"
+    outdoor_sports_act_loc_disp = 5185, "Location Display Device"
+    outdoor_sports_act_loc_and_nav_disp = 5186, "Location and Navigation Display Device"
+    outdoor_sports_act_loc_pod = 5187, "Location Pod"
+    outdoor_sports_act_loc_and_nav_pod = 5188, "Location and Navigation Pod"
+
+    def as_bytes(self):
+        return struct.pack("<H", self)

--- a/blatann/examples/peripheral.py
+++ b/blatann/examples/peripheral.py
@@ -11,7 +11,10 @@ import struct
 import threading
 import time
 
+from blatann.peer import ConnectionParameters
+
 from blatann import BleDevice
+from blatann.bt_sig.assigned_numbers import Appearance
 from blatann.uuid import Uuid16
 from blatann.examples import example_utils, constants
 from blatann.gap import advertising, smp, IoCapabilities
@@ -239,6 +242,10 @@ def main(serial_port):
     ble_device.configure()
     ble_device.open()
 
+    # Demo of setting parameters in the Generic Access service, not required tp set any parameters here
+    ble_device.generic_access_service.device_name = "Peripheral Example"
+    ble_device.generic_access_service.appearance = Appearance.computer
+
     # Set up desired security parameters
     ble_device.client.security.set_security_params(passcode_pairing=False, bond=False, lesc_pairing=False,
                                                    io_capabilities=IoCapabilities.DISPLAY_ONLY, out_of_band=False)
@@ -273,7 +280,8 @@ def main(serial_port):
 
     # Initialize the advertising and scan response data
     adv_data = advertising.AdvertisingData(local_name=constants.PERIPHERAL_NAME, flags=0x06)
-    scan_data = advertising.AdvertisingData(service_uuid128s=constants.TIME_SERVICE_UUID, has_more_uuid128_services=True)
+    scan_data = advertising.AdvertisingData(service_uuid128s=constants.TIME_SERVICE_UUID, has_more_uuid128_services=True,
+                                            appearance=ble_device.generic_access_service.appearance)
     ble_device.advertiser.set_advertise_data(adv_data, scan_data)
 
     # Start advertising

--- a/blatann/gap/advertise_data.py
+++ b/blatann/gap/advertise_data.py
@@ -157,9 +157,10 @@ class AdvertisingData(object):
             records[t] = self.local_name
 
         for k, v in records.items():
-            if isinstance(v, int):
+            if hasattr(v, "as_bytes"):
+                records[k] = v.as_bytes()
+            elif isinstance(v, int):
                 records[k] = [v]
-
         record_string_keys = {k.name: v for k, v in records.items()}
         return nrf_types.BLEAdvData(**record_string_keys)
 

--- a/blatann/gap/generic_access_service.py
+++ b/blatann/gap/generic_access_service.py
@@ -1,0 +1,95 @@
+import logging
+from typing import Optional
+
+from blatann.bt_sig.assigned_numbers import Appearance
+from blatann.peer import ConnectionParameters, Union
+from blatann.nrf import nrf_types
+
+logger = logging.getLogger(__name__)
+
+
+class GenericAccessService:
+    """
+    Class which represents the Generic Access service within the local database
+    """
+    DEVICE_NAME_MAX_LENGTH = 31
+
+    def __init__(self, ble_driver,
+                 device_name=nrf_types.driver.BLE_GAP_DEVNAME_DEFAULT,
+                 appearance=Appearance.unknown):
+        """
+        :type ble_driver: blatann.nrf.nrf_driver.NrfDriver
+        :type device_name: str
+        """
+        self.ble_driver = ble_driver
+        self._name = device_name
+        self._appearance = appearance
+        self._empty_conn_params = None
+        self._preferred_conn_params: Optional[ConnectionParameters] = None
+
+    @property
+    def device_name(self) -> str:
+        """
+        The device name that is configured in the Generic Access service of the local GATT database
+
+        :getter: Gets the current device name
+        :setter: Sets the current device name. Length (after utf8 encoding) must be <= 31 bytes
+        """
+        return self._name
+
+    @device_name.setter
+    def device_name(self, name: str):
+        name_bytes = name.encode("utf8")
+        if len(name_bytes) > self.DEVICE_NAME_MAX_LENGTH:
+            raise ValueError(f"Encoded device name must be <= {self.DEVICE_NAME_MAX_LENGTH} bytes")
+        if self.ble_driver.is_open:
+            self.ble_driver.ble_gap_device_name_set(name_bytes)
+        self._name = name
+
+    @property
+    def appearance(self) -> Appearance:
+        """
+        The Appearance that is configured in the Generic Access service of the local GATT database
+
+        :getter: Gets the device appearance
+        :setter: Sets the device appearance
+        """
+        return self._appearance
+
+    @appearance.setter
+    def appearance(self, value: Union[Appearance, int]):
+        if self.ble_driver.is_open:
+            self.ble_driver.ble_gap_appearance_set(value)
+        self._appearance = value
+
+    @property
+    def preferred_peripheral_connection_params(self) -> Optional[ConnectionParameters]:
+        """
+        The preferred peripheral connection parameters that are configured in the Generic Access service
+        of the local GATT Database. If not configured, returns None.
+
+        :getter: Gets the configured connection parameters or None if not configured
+        :setter: Sets the configured connection parameters
+        """
+        return self._preferred_conn_params
+
+    @preferred_peripheral_connection_params.setter
+    def preferred_peripheral_connection_params(self, value: ConnectionParameters):
+        if self.ble_driver.is_open:
+            self.ble_driver.ble_gap_ppcp_set(value)
+        self._preferred_conn_params = value
+
+    def update(self):
+        """
+        **Not to be called by users**
+
+        Used internally to configure the generic access in the case that values were set before
+        the driver was opened and configured.
+        """
+        if not self.ble_driver.is_open:
+            return
+        name_bytes = self._name.encode("utf8")
+        self.ble_driver.ble_gap_device_name_set(name_bytes)
+        self.ble_driver.ble_gap_appearance_set(self._appearance)
+        if self._preferred_conn_params:
+            self.ble_driver.ble_gap_ppcp_set(self._preferred_conn_params)

--- a/blatann/nrf/nrf_driver.py
+++ b/blatann/nrf/nrf_driver.py
@@ -293,6 +293,28 @@ class NrfDriver(object):
 
     @NordicSemiErrorCheck
     @wrapt.synchronized(api_lock)
+    def ble_gap_device_name_set(self, name):
+        if isinstance(name, str):
+            name = name.encode("utf8")
+        write_perm = BLEGapSecMode(0, 0).to_c()
+        length = len(name)
+        data = util.list_to_uint8_array(name).cast()
+        return driver.sd_ble_gap_device_name_set(self.rpc_adapter, write_perm, data, length)
+
+    @NordicSemiErrorCheck
+    @wrapt.synchronized(api_lock)
+    def ble_gap_appearance_set(self, value):
+        return driver.sd_ble_gap_appearance_set(self.rpc_adapter, value)
+
+    @NordicSemiErrorCheck
+    @wrapt.synchronized(api_lock)
+    def ble_gap_ppcp_set(self, conn_params):
+        assert isinstance(conn_params, BLEGapConnParams), "Invalid argument type"
+        params = conn_params.to_c()
+        return driver.sd_ble_gap_ppcp_set(self.rpc_adapter, params)
+
+    @NordicSemiErrorCheck
+    @wrapt.synchronized(api_lock)
     def ble_gap_adv_start(self, adv_params=None, conn_cfg_tag=0):
         if not adv_params:
             adv_params = self.adv_params_setup()

--- a/blatann/nrf/nrf_types/config.py
+++ b/blatann/nrf/nrf_types/config.py
@@ -205,15 +205,13 @@ class BleEnableConfig(object):
                  central_role_count=driver.BLE_GAP_ROLE_COUNT_CENTRAL_DEFAULT,
                  central_sec_count=driver.BLE_GAP_ROLE_COUNT_CENTRAL_DEFAULT,
                  service_changed_char=driver.BLE_GATTS_SERVICE_CHANGED_DEFAULT,
-                 attr_table_size=driver.BLE_GATTS_ATTR_TAB_SIZE_DEFAULT,
-                 device_name=""):
+                 attr_table_size=driver.BLE_GATTS_ATTR_TAB_SIZE_DEFAULT):
         self.vs_uuid_count = vs_uuid_count
         self.periph_role_count = periph_role_count
         self.central_role_count = central_role_count
         self.central_sec_count = central_sec_count
         self.service_changed_char = service_changed_char
         self.attr_table_size = attr_table_size
-        self.device_name = device_name
 
     def get_vs_uuid_cfg(self):
         config = driver.ble_cfg_t()
@@ -234,12 +232,11 @@ class BleEnableConfig(object):
     def get_device_name_cfg(self):
         config = driver.ble_cfg_t()
         cfg = config.gap_cfg.device_name_cfg
-        cfg.current_len = len(self.device_name)
-        cfg.max_len = cfg.current_len
-        cfg.p_value = util.list_to_uint8_array(self.device_name).cast()
+        cfg.current_len = 0
+        cfg.max_len = driver.BLE_GAP_DEVNAME_DEFAULT_LEN
         cfg.write_perm.sm = 0
         cfg.write_perm.lv = 0
-        cfg.vloc = driver.BLE_GATTS_VLOC_USER
+        cfg.vloc = driver.BLE_GATTS_VLOC_STACK
 
         return driver.BLE_GAP_CFG_DEVICE_NAME, config
 

--- a/blatann/nrf/nrf_types/gap.py
+++ b/blatann/nrf/nrf_types/gap.py
@@ -277,7 +277,8 @@ class BLEAdvData(object):
 
             elif isinstance(self.records[k], list):
                 data_list.extend(self.records[k])
-
+            elif isinstance(self.records[k], bytes):
+                data_list.extend(self.records[k])
             else:
                 raise NordicSemiException('Unsupported value type: 0x{:02X}'.format(type(self.records[k])))
         self.raw_bytes = bytes(data_list)

--- a/docs/source/blatann.examples.multirole.rst
+++ b/docs/source/blatann.examples.multirole.rst
@@ -1,7 +1,0 @@
-blatann.examples.multirole module
-=================================
-
-.. automodule:: blatann.examples.multirole
-   :members:
-   :undoc-members:
-   :show-inheritance:

--- a/docs/source/blatann.examples.rst
+++ b/docs/source/blatann.examples.rst
@@ -21,7 +21,6 @@ Submodules
    blatann.examples.central_event_driven
    blatann.examples.constants
    blatann.examples.example_utils
-   blatann.examples.multirole
    blatann.examples.peripheral
    blatann.examples.peripheral_battery_service
    blatann.examples.peripheral_current_time_service

--- a/docs/source/blatann.gap.generic_access_service.rst
+++ b/docs/source/blatann.gap.generic_access_service.rst
@@ -1,0 +1,7 @@
+blatann.gap.generic\_access\_service module
+===========================================
+
+.. automodule:: blatann.gap.generic_access_service
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/blatann.gap.rst
+++ b/docs/source/blatann.gap.rst
@@ -16,6 +16,7 @@ Submodules
    blatann.gap.advertising
    blatann.gap.bond_db
    blatann.gap.default_bond_db
+   blatann.gap.generic_access_service
    blatann.gap.scanning
    blatann.gap.smp
    blatann.gap.smp_crypto


### PR DESCRIPTION
Can set/get:
- Device Name
- Appearance (enum added)
- Preferred Peripheral Connection Parameters

Other Advertising Data Improvements:
- Can now use `bytes` for advertising data types (e.g. `AdvertisingData(service_data=b"abcd")`)
- Can use any object type in advertising data if it has an `as_bytes()` method that can be used to convert the object to bytes
