### PR TITLE
Adds support for using the SoftDevice Tx queues for notifications and write commands

### DIFF
--- a/blatann/device.py
+++ b/blatann/device.py
@@ -92,16 +92,17 @@ class BleDevice(NrfDriverObserver):
     Represents the Bluetooth device itself. Provides the high-level bluetooth APIs (Advertising, Scanning, Connections),
     configuration, and bond database
     """
-    def __init__(self, comport="COM1", baud=1000000, log_driver_comms=False):
+    def __init__(self, comport="COM1", baud=1000000, log_driver_comms=False,
+                 notification_hw_queue_size=16, write_command_hw_queue_size=16):
         self.ble_driver = NrfDriver(comport, baud, log_driver_comms)
         self.event_logger = _EventLogger(self.ble_driver)
         self.ble_driver.observer_register(self)
         self.ble_driver.event_subscribe(self._on_user_mem_request, nrf_events.EvtUserMemoryRequest)
         self.ble_driver.event_subscribe(self._on_sys_attr_missing, nrf_events.GattsEvtSysAttrMissing)
         self._ble_configuration = self.ble_driver.ble_enable_params_setup()
-        self._default_conn_config = nrf_types.BleConnConfig(event_length=6,              # Minimum event length required for max DLE
-                                                            hvn_tx_queue_size=16,        # Hardware queue of 16 notifications
-                                                            write_cmd_tx_queue_size=16)  # Hardware queue of 16 write cmds (no response)
+        self._default_conn_config = nrf_types.BleConnConfig(event_length=6,                                       # Minimum event length required for max DLE
+                                                            hvn_tx_queue_size=notification_hw_queue_size,         # Hardware queue of 16 notifications
+                                                            write_cmd_tx_queue_size=write_command_hw_queue_size)  # Hardware queue of 16 write cmds (no response)
 
         self.bond_db_loader = default_bond_db.DefaultBondDatabaseLoader()
         self.bond_db = default_bond_db.DefaultBondDatabase()

--- a/blatann/device.py
+++ b/blatann/device.py
@@ -99,7 +99,9 @@ class BleDevice(NrfDriverObserver):
         self.ble_driver.event_subscribe(self._on_user_mem_request, nrf_events.EvtUserMemoryRequest)
         self.ble_driver.event_subscribe(self._on_sys_attr_missing, nrf_events.GattsEvtSysAttrMissing)
         self._ble_configuration = self.ble_driver.ble_enable_params_setup()
-        self._default_conn_config = nrf_types.BleConnConfig(event_length=6)  # The minimum event length which supports max DLE
+        self._default_conn_config = nrf_types.BleConnConfig(event_length=6,              # Minimum event length required for max DLE
+                                                            hvn_tx_queue_size=16,        # Hardware queue of 16 notifications
+                                                            write_cmd_tx_queue_size=16)  # Hardware queue of 16 write cmds (no response)
 
         self.bond_db_loader = default_bond_db.DefaultBondDatabaseLoader()
         self.bond_db = default_bond_db.DefaultBondDatabase()
@@ -112,7 +114,7 @@ class BleDevice(NrfDriverObserver):
         self.advertiser = advertising.Advertiser(self, self.client, self._default_conn_config.conn_tag)
         self.scanner = scanning.Scanner(self)
         self._generic_access_service = GenericAccessService(self.ble_driver)
-        self._db = gatts.GattsDatabase(self, self.client)
+        self._db = gatts.GattsDatabase(self, self.client, self._default_conn_config.hvn_tx_queue_size)
         self._default_conn_params = peer.DEFAULT_CONNECTION_PARAMS
         self._default_security_params = peer.DEFAULT_SECURITY_PARAMS
         self._att_mtu_max = MTU_SIZE_MINIMUM
@@ -257,7 +259,8 @@ class BleDevice(NrfDriverObserver):
         if not connection_params:
             connection_params = self._default_conn_params
 
-        self.connecting_peripheral = peer.Peripheral(self, peer_address, connection_params, self._default_security_params, name)
+        self.connecting_peripheral = peer.Peripheral(self, peer_address, connection_params, self._default_security_params, name,
+                                                     self._default_conn_config.write_cmd_tx_queue_size)
         periph_connection_waitable = PeripheralConnectionWaitable(self, self.connecting_peripheral)
         self.ble_driver.ble_gap_connect(peer_address, conn_params=connection_params,
                                         conn_cfg_tag=self._default_conn_config.conn_tag)

--- a/blatann/gatt/__init__.py
+++ b/blatann/gatt/__init__.py
@@ -33,6 +33,11 @@ LONG_WRITE_BYTE_OVERHEAD = 5
 NOTIFICATION_BYTE_OVERHEAD = 3
 READ_BYTE_OVERHEAD = 1
 
+# Maximum value for data length
+DLE_MAX = 251
+DLE_MIN = 27
+DLE_OVERHEAD = 4
+
 """
 Status codes that can be returned during GATT Operations (reads, writes, etc.)
 """

--- a/blatann/gatt/gattc.py
+++ b/blatann/gatt/gattc.py
@@ -4,7 +4,7 @@ from typing import List, Optional, Iterable
 
 from blatann import gatt
 from blatann.gatt.gattc_attribute import GattcAttribute
-from blatann.gatt.managers import _ReadWriteManager
+from blatann.gatt.managers import GattcOperationManager
 from blatann.bt_sig.uuids import Uuid, DeclarationUuid, DescriptorUuid
 from blatann.event_type import EventSource, Event
 from blatann.gatt.reader import GattcReader
@@ -342,7 +342,7 @@ class GattcCharacteristic(gatt.Characteristic):
 
         :type ble_device: blatann.BleDevice
         :type peer: blatann.peer.Peer
-        :type read_write_manager: _ReadWriteManager
+        :type read_write_manager: GattcOperationManager
         :type nrf_characteristic: nrf_types.BLEGattCharacteristic
         """
         char_decl_uuid = DeclarationUuid.characteristic
@@ -418,7 +418,7 @@ class GattcService(gatt.Service):
 
         :type ble_device: blatann.device.BleDevice
         :type peer: blatann.peer.Peer
-        :type read_write_manager: _ReadWriteManager
+        :type read_write_manager: GattcOperationManager
         :type nrf_service: nrf_types.BLEGattService
         """
         service_uuid = ble_device.uuid_manager.nrf_uuid_to_uuid(nrf_service.uuid)
@@ -435,11 +435,11 @@ class GattcDatabase(gatt.GattDatabase):
     Represents a remote GATT Database which lives on a connected peripheral. Contains all discovered services,
     characteristics, and descriptors
     """
-    def __init__(self, ble_device, peer):
+    def __init__(self, ble_device, peer, write_no_resp_queue_size=1):
         super(GattcDatabase, self).__init__(ble_device, peer)
         self._writer = GattcWriter(ble_device, peer)
         self._reader = GattcReader(ble_device, peer)
-        self._read_write_manager = _ReadWriteManager(self._reader, self._writer)
+        self._read_write_manager = GattcOperationManager(ble_device, peer, self._reader, self._writer, write_no_resp_queue_size)
 
     @property
     def services(self) -> List[GattcService]:

--- a/blatann/gatt/gattc_attribute.py
+++ b/blatann/gatt/gattc_attribute.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 
 from blatann.gatt import Attribute
-from blatann.gatt.managers import _ReadWriteManager
+from blatann.gatt.managers import GattcOperationManager
 from blatann.nrf import nrf_types
 from blatann.waitables.event_waitable import EventWaitable, IdBasedEventWaitable
 from blatann.event_args import ReadCompleteEventArgs, WriteCompleteEventArgs
@@ -18,7 +18,7 @@ class GattcAttribute(Attribute):
     """
     Represents a client-side interface to a single attribute which lives inside a Characteristic
     """
-    def __init__(self, uuid: Uuid, handle: int, read_write_manager: _ReadWriteManager,
+    def __init__(self, uuid: Uuid, handle: int, read_write_manager: GattcOperationManager,
                  initial_value=b"", string_encoding="utf8"):
         super(GattcAttribute, self).__init__(uuid, handle, initial_value, string_encoding)
         self._manager = read_write_manager

--- a/blatann/nrf/nrf_types/gap.py
+++ b/blatann/nrf/nrf_types/gap.py
@@ -1,5 +1,7 @@
 from enum import Enum, IntEnum
 import logging
+
+from blatann.utils import repr_format
 from pc_ble_driver_py.exceptions import NordicSemiException
 from blatann.nrf.nrf_dll_load import driver
 import blatann.nrf.nrf_driver_types as util
@@ -338,6 +340,9 @@ class BLEGapDataLengthParams(object):
         params.max_tx_time_us = self.max_tx_time_us
         params.max_rx_time_us = self.max_rx_time_us
         return params
+
+    def __repr__(self):
+        return repr_format(self, tx=self.max_tx_octets, rx=self.max_rx_octets)
 
 
 class BLEGapPhys(object):

--- a/blatann/peer.py
+++ b/blatann/peer.py
@@ -106,7 +106,7 @@ class Peer(object):
 
     def __init__(self, ble_device, role, connection_params=DEFAULT_CONNECTION_PARAMS,
                  security_params=DEFAULT_SECURITY_PARAMS,
-                 name=""):
+                 name="", write_no_resp_queue_size=1):
         """
         :type ble_device: blatann.device.BleDevice
         """
@@ -132,7 +132,7 @@ class Peer(object):
         self._connection_handler_lock = threading.Lock()
 
         self.security = smp.SecurityManager(self._ble_device, self, security_params)
-        self._db = gattc.GattcDatabase(ble_device, self)
+        self._db = gattc.GattcDatabase(ble_device, self, write_no_resp_queue_size)
         self._discoverer = service_discovery.DatabaseDiscoverer(ble_device, self)
 
     """
@@ -550,9 +550,10 @@ class Peripheral(Peer):
     def __init__(self, ble_device, peer_address,
                  connection_params=DEFAULT_CONNECTION_PARAMS,
                  security_params=DEFAULT_SECURITY_PARAMS,
-                 name=""):
+                 name="",
+                 write_no_resp_queue_size=1):
         super(Peripheral, self).__init__(ble_device, nrf_events.BLEGapRoles.central, connection_params,
-                                         security_params, name)
+                                         security_params, name, write_no_resp_queue_size)
         self.peer_address = peer_address
         self.connection_state = PeerState.CONNECTING
 
@@ -564,9 +565,10 @@ class Client(Peer):
     def __init__(self, ble_device,
                  connection_params=DEFAULT_CONNECTION_PARAMS,
                  security_params=DEFAULT_SECURITY_PARAMS,
-                 name=""):
+                 name="",
+                 write_no_resp_queue_size=1):
         super(Client, self).__init__(ble_device, nrf_events.BLEGapRoles.periph, connection_params,
-                                     security_params, name)
+                                     security_params, name, write_no_resp_queue_size)
         self._first_connection = True
 
     def peer_connected(self, conn_handle, peer_address, connection_params):

--- a/blatann/utils/queued_tasks_manager.py
+++ b/blatann/utils/queued_tasks_manager.py
@@ -1,12 +1,15 @@
 import threading
+from typing import Generic, Optional, TypeVar
 import queue
 import logging
 
 
 logger = logging.getLogger(__name__)
 
+T = TypeVar("T")
 
-class QueuedTasksManagerBase(object):
+
+class QueuedTasksManagerBase(Generic[T]):
     """
     Handles queuing of tasks that can only be done one at a time
     """
@@ -16,68 +19,86 @@ class QueuedTasksManagerBase(object):
             self.clear_all = clear_all
             self.reason = reason
 
-    def __init__(self):
-        self._queue = queue.Queue()
-        self._in_process = threading.Event()
+    def __init__(self, max_processing_items_at_once=1):
+        self._input_queue = queue.Queue()
         self._lock = threading.RLock()
+        self._in_process_queue = queue.Queue(max_processing_items_at_once)
 
-    def _add_task(self, task):
+    def _add_task(self, task: T):
         with self._lock:
-            if self._in_process.is_set():
-                self._queue.put(task)
+            # Cannot process any more tasks currently, add to input queue
+            if self._in_process_queue.full():
+                self._input_queue.put(task)
             else:
                 try:
+                    # Handle the task. If it's not complete put it in the in process queue
                     task_complete = self._handle_task(task)
                     if not task_complete:
-                        self._in_process.set()
+                        self._in_process_queue.put_nowait(task)
                 except Exception as e:
                     self._process_exception(task, e)
 
-    def _task_completed(self, task):
+    def _pop_task_in_process(self) -> Optional[T]:
+        # Pops the earliest task from the process queue, will be completed shortly
         with self._lock:
-            task = self._get_next()
+            return self._get_next(self._in_process_queue)
+
+    def _task_completed(self, task: T):
+        with self._lock:
+            # Ensure the queue wasn't filled by another thread
+            if self._in_process_queue.full():
+                return
+            # Start processing tasks from the input queue
+            task = self._get_next(self._input_queue)
             while task:
                 try:
                     task_complete = self._handle_task(task)
                     if not task_complete:
-                        break
+                        # Task is still in process, add to the queue and if full break out of the loop
+                        self._in_process_queue.put_nowait(task)
+                        if self._in_process_queue.full():
+                            break
                 except Exception as e:
                     self._process_exception(task, e)
-                task = self._get_next()
+                task = self._get_next(self._input_queue)
 
-            if not task:
-                self._in_process.clear()
-
-    def _process_exception(self, task, e):
+    def _process_exception(self, task: T, e: Exception):
         action = self._handle_task_failure(task, e)
         if not action.ignore_stack_trace:
             logger.exception(e)
         if action.clear_all:
             self._clear_all(action.reason)
 
-    def _get_next(self):
+    def _get_next(self, q: queue.Queue) -> Optional[T]:
+        if not q:
+            q = self._input_queue
         try:
-            return self._queue.get_nowait()
+            return q.get_nowait()
         except queue.Empty:
             return None
 
     def _clear_all(self, reason):
         with self._lock:
-            task = self._get_next()
+            # Clear the process queue, then clear the input queue
+            task = self._get_next(self._in_process_queue)
             while task:
                 self._handle_task_cleared(task, reason)
-                task = self._get_next()
-            self._in_process.clear()
+                task = self._get_next(self._in_process_queue)
+
+            # Clear the input queue
+            task = self._get_next(self._input_queue)
+            while task:
+                self._handle_task_cleared(task, reason)
+                task = self._get_next(self._input_queue)
 
     def clear_all(self):
         raise NotImplementedError()
 
-    def _handle_task(self, task):
+    def _handle_task(self, task: T):
         raise NotImplementedError()
 
-    def _handle_task_failure(self, task, e) -> TaskFailure:
+    def _handle_task_failure(self, task: T, e: Exception) -> TaskFailure:
         raise NotImplementedError()
 
-    def _handle_task_cleared(self, task, reason):
+    def _handle_task_cleared(self, task: T, reason):
         raise NotImplementedError()
-

--- a/tests/integrated/test_gatt_writes.py
+++ b/tests/integrated/test_gatt_writes.py
@@ -105,6 +105,7 @@ class TestGattWrites(BlatannTestCase):
         self.assertIsNotNone(self.central_conn.write_no_resp_char)
         self.assertTrue(self.central_conn.write_char.writable)
         self.assertTrue(self.central_conn.write_no_resp_char.writable_without_response)
+        self.write_size = self.periph_conn.peer.mtu_size - 3
 
     def _run_throughput_test(self, periph_char: GattsCharacteristic, central_char: GattcCharacteristic, data_size=20000):
         # Queue up 20k of data, track the time it takes to send


### PR DESCRIPTION
Changes take advantage of the Notification and Write command queues present on the Nordic S132 softdevice in order to increase throughput.

- Both Notification and Write Command queues default to 16, configurable when creating the BLE Device (slight departure from the `configure()` method, but is needed to initialize the software-mirrored queue when the device is created)
  - Software queueing is still used for instances where > 16 notifications/write commands are queued up at once. New approach is more or less a 2-stage queue-- first input stage is unlimited and the second is hardware-limited
- Notifications and Write commands are handled by separate `QueuedTaskManager`s from their Indication and read/write request counterparts to facilitate this behavior. Indications, Read requests and Write requests have a fixed hardware queue of 1 but can be queued simultaneously alongside notifications/write commands
- Throughput using Writes commands increases by 2x (previous benchmark was ~15kbyte/s, with changes is ~30kbyte/s)
  - Increasing queue size past 16 did not seem to have a noticeable impact, however decreasing MTU to 230 (from 247) at the minimum 7.5ms connection interval bumped the throughput up to ~40kbyte/s
- Updates the glucose service implementation to take advantage of hardware queuing to increase the speed of reporting glucose measurements
- Updates the data length update procedure to optimize the data length according to MTU size, with new parameter to set a specific requested DLE size
- 