### PR TITLE
- use the peers ltk for ble_gap_encrypt (peer is peripheral)

### DIFF
--- a/blatann/gap/smp.py
+++ b/blatann/gap/smp.py
@@ -297,8 +297,8 @@ class SecurityManager(object):
             if bond_entry:
                 logger.info("Re-establishing encryption with peer using LTKs")
                 self.ble_device.ble_driver.ble_gap_encrypt(self.peer.conn_handle,
-                                                           bond_entry.bonding_data.own_ltk.master_id,
-                                                           bond_entry.bonding_data.own_ltk.enc_info)
+                                                           bond_entry.bonding_data.peer_ltk.master_id,
+                                                           bond_entry.bonding_data.peer_ltk.enc_info)
                 self._initiated_encryption = True
                 return EventWaitable(self.on_pairing_complete)
 


### PR DESCRIPTION
I am using two Nordic Dongles with blatann, one as Central, the other as Peripheral. Pairing and Bonding works, but when I try to re-connect the bonded devices, I get a mic failure. I think pair() should use the peers ltk when it is called on the Central device, at least it works with my two dongles (I was able to re-connect from a smartphone to the Peripheral-Dongle, so I expected the Central dongle to cause the issue)