### PR TITLE
- add a security level for writing the cccd (reading is always allowed)

### DIFF
--- a/blatann/gatt/gatts.py
+++ b/blatann/gatt/gatts.py
@@ -68,9 +68,9 @@ class GattsCharacteristicProperties(gatt.CharacteristicProperties):
     def __init__(self, read=True, write=False, notify=False, indicate=False, broadcast=False,
                  write_no_response=False, signed_write=False, security_level=gatt.SecurityLevel.OPEN,
                  max_length=20, variable_length=True, sccd=False,
-                 cccd_write_security_level=gatt.SecurityLevel.OPEN,
                  user_description: GattsUserDescriptionProperties = None,
-                 presentation_format: PresentationFormat = None):
+                 presentation_format: PresentationFormat = None,
+                 cccd_write_security_level=gatt.SecurityLevel.OPEN):
         super(GattsCharacteristicProperties, self).__init__(read, write, notify, indicate, broadcast,
                                                             write_no_response, signed_write)
         self.security_level = security_level

--- a/blatann/gatt/gatts.py
+++ b/blatann/gatt/gatts.py
@@ -68,6 +68,7 @@ class GattsCharacteristicProperties(gatt.CharacteristicProperties):
     def __init__(self, read=True, write=False, notify=False, indicate=False, broadcast=False,
                  write_no_response=False, signed_write=False, security_level=gatt.SecurityLevel.OPEN,
                  max_length=20, variable_length=True, sccd=False,
+                 cccd_security_level=gatt.SecurityLevel.OPEN,
                  user_description: GattsUserDescriptionProperties = None,
                  presentation_format: PresentationFormat = None):
         super(GattsCharacteristicProperties, self).__init__(read, write, notify, indicate, broadcast,
@@ -78,6 +79,7 @@ class GattsCharacteristicProperties(gatt.CharacteristicProperties):
         self.user_description = user_description
         self.presentation = presentation_format
         self.sccd = sccd
+        self.cccd_security_level = cccd_security_level
 
 
 class GattsCharacteristic(gatt.Characteristic):
@@ -466,7 +468,7 @@ class GattsService(gatt.Service):
         char_md = nrf_types.BLEGattsCharMetadata(props)
         # Create cccd metadata if notify/indicate enabled
         if properties.notify or properties.indicate:
-            char_md.cccd_metadata = nrf_types.BLEGattsAttrMetadata()
+            char_md.cccd_metadata = nrf_types.BLEGattsAttrMetadata(write_permissions=_security_mapping[properties.cccd_security_level])
 
         if properties.sccd:
             char_md.sccd_metadata = nrf_types.BLEGattsAttrMetadata()

--- a/blatann/gatt/gatts.py
+++ b/blatann/gatt/gatts.py
@@ -68,7 +68,7 @@ class GattsCharacteristicProperties(gatt.CharacteristicProperties):
     def __init__(self, read=True, write=False, notify=False, indicate=False, broadcast=False,
                  write_no_response=False, signed_write=False, security_level=gatt.SecurityLevel.OPEN,
                  max_length=20, variable_length=True, sccd=False,
-                 cccd_security_level=gatt.SecurityLevel.OPEN,
+                 cccd_write_security_level=gatt.SecurityLevel.OPEN,
                  user_description: GattsUserDescriptionProperties = None,
                  presentation_format: PresentationFormat = None):
         super(GattsCharacteristicProperties, self).__init__(read, write, notify, indicate, broadcast,
@@ -79,7 +79,7 @@ class GattsCharacteristicProperties(gatt.CharacteristicProperties):
         self.user_description = user_description
         self.presentation = presentation_format
         self.sccd = sccd
-        self.cccd_security_level = cccd_security_level
+        self.cccd_write_security_level = cccd_write_security_level
 
 
 class GattsCharacteristic(gatt.Characteristic):
@@ -468,7 +468,7 @@ class GattsService(gatt.Service):
         char_md = nrf_types.BLEGattsCharMetadata(props)
         # Create cccd metadata if notify/indicate enabled
         if properties.notify or properties.indicate:
-            char_md.cccd_metadata = nrf_types.BLEGattsAttrMetadata(write_permissions=_security_mapping[properties.cccd_security_level])
+            char_md.cccd_metadata = nrf_types.BLEGattsAttrMetadata(write_permissions=_security_mapping[properties.cccd_write_security_level])
 
         if properties.sccd:
             char_md.sccd_metadata = nrf_types.BLEGattsAttrMetadata()


### PR DESCRIPTION
This might be related to https://github.com/ThomasGerstenberg/blatann/issues/10:

It would be good to set the security level for writing a cccd. 

Example: 
You have a service for bi-directional communication. The service has a notification characteristic for receiving data and a write-no-response (for maximum throughput) for sending data. The communication should be encrypted.

Currently there is no trigger to enforce encryption even if both characteristics have a security level > SecurityLevel.OPEN 

Being able to assign e.g. SecurityLevel.JUST_WORKS for writing to the cccd of the notification would trigger a "Insufficient Authentication" response which then results in a pairing/bonding 