### PR TITLE
Bonding improvements

### DIFF
--- a/blatann/event_args.py
+++ b/blatann/event_args.py
@@ -84,19 +84,28 @@ class PhyUpdatedEventArgs(EventArgs):
 
 # SMP Event Args
 
+class SecurityProcess(Enum):
+    ENCRYPTION = 0  # Re-established security using existing long-term keys
+    PAIRING = 1     # Created new short-term keys, but no bonding performed
+    BONDING = 1     # Created new long-term keys
+
+
 class PairingCompleteEventArgs(EventArgs):
     """
     Event arguments when pairing completes, whether it failed or was successful
     """
-    def __init__(self, status, security_level):
+    def __init__(self, status, security_level, security_process):
         """
         :param status: The pairing status
         :type status: blatann.gap.SecurityStatus
         :param security_level: The security level after pairing/bonding
         :type security_level: blatann.gap.smp.SecurityLevel
+        :param security_process: The process that was performed
+        :type security_process: SecurityProcess
         """
         self.status = status
         self.security_level = security_level
+        self.security_process = security_process
 
 
 class SecurityLevelChangedEventArgs(EventArgs):


### PR DESCRIPTION
Fixes several issues with bonding and improves test coverage

- LESC bond restoration requires using our own LTKs. This is different than legacy encryption which uses the peer's LTKs
- Improves how bond data records are found in the bond database. For LESC bonds it was incorrectly trying to match against Master IDs which are only used for legacy pairing
- Adds new field to `PairingCompleteEventArgs` indicating the security process that completed (encryption, pairing, or bonding)
- Increases test coverage for bonding scenarios, including legacy bonding. Previous version of tests were only creating LTKs but did not attempt to reconnect and re-establish encryption using said LTKs