### PR TITLE
adds bond db file param to the BleDevice constructor

### DIFF
--- a/tests/integrated/base.py
+++ b/tests/integrated/base.py
@@ -26,8 +26,7 @@ def _configure_device(dev_number, config, optional=False):
         if optional:
             return None
         raise EnvironmentError(f"Environment variable {env_key} must be defined with the device's comport")
-    dev = BleDevice(comport)
-    dev.bond_db_loader = DefaultBondDatabaseLoader(BOND_DB_FILE_FMT.format(dev_number))
+    dev = BleDevice(comport, bond_db_filename=BOND_DB_FILE_FMT.format(dev_number))
     dev.configure(**config)
     dev.event_logger.suppress(nrf_events.GapEvtAdvReport)
     return dev


### PR DESCRIPTION
Also moves the bond db file to be saved to `~/.blatann` by default. For the previous implementation `"system"` can be specified to save it within package contents

Fixes #60 