### PR TITLE
Fixed uncaught exception that could occur inside a failed to load bond db exception.

### DIFF
--- a/blatann/gap/default_bond_db.py
+++ b/blatann/gap/default_bond_db.py
@@ -33,7 +33,7 @@ class DefaultBondDatabaseLoader(BondDatabaseLoader):
                 logger.info("Loaded Bond DB '{}'".format(self.filename))
                 return db
         except Exception as e:
-            logger.error("Failed to load Bond DB '{}' -  {}:{}".format(self.filename, type(e).__name__, e.message))
+            logger.exception("Failed to load Bond DB '{}'".format(self.filename))
             return DefaultBondDatabase()
 
     def save(self, db):


### PR DESCRIPTION
## Issue
```EOFError' object has no attribute 'message'```
was raised inside the `except Exception as e` block. 
The `message` attribute is not available in Python >= 3.