### PR TITLE
add macos shell script to retarget pc-ble-driver-py

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,17 +18,9 @@ Documentation is available on [ReadTheDocs](https://blatann.readthedocs.io)
 In order to use it with brew's python install, you'll need to run `install_name_tool` to modify the `.so` to 
 point to brew python instead of system python.
 
-Example shell script to do so, which should be run after blatann is installed into your python env of choice:
-```shell
-# Adjust versions as needed and double-check these paths before running
-SYSTEM_PYTHON=/System/Library/Frameworks/Python.framework/Versions/3.9/Python
-SITE_PACKAGES=`python -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())"` # Make sure you're in the correct env/virtualenv first!
-PC_BLE_DRIVER_LOC=$SITE_PACKAGES/pc_ble_driver_py/lib/macos
-BREW_PYTHON=/usr/local/Cellar/python@3.8/3.8.3_2/Frameworks/Python.framework/Versions/3.8/lib/libpython3.8.dylib
+_Note: This is the case with any custom-installed python on mac (like anaconda), brew is the most popular and what has been tested_
 
-install_name_tool -change $SYSTEM_PYTHON $BREW_PYTHON $PC_BLE_DRIVER_LOC/_pc_ble_driver_sd_api_v2.so
-install_name_tool -change $SYSTEM_PYTHON $BREW_PYTHON $PC_BLE_DRIVER_LOC/_pc_ble_driver_sd_api_v5.so
-```
+An example shell script to do so can be found [here](./tools/macos_retarget_pc_ble_driver_py.sh)  
 
 #### Supported Devices/Software
 

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -33,18 +33,8 @@ Running with macOS brew python
 In order to use it with brew's python install, you'll need to run ``install_name_tool`` to modify the ``.so`` to
 point to brew python instead of system python.
 
-Example shell script to do so, which should be run after blatann is installed into your python env of choice:
-
-.. code-block:: shell
-
-   # Adjust versions as needed and double-check these paths before running
-   SYSTEM_PYTHON=/System/Library/Frameworks/Python.framework/Versions/3.9/Python
-   SITE_PACKAGES=`python -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())"` # Make sure you're in the correct env/virtualenv first!
-   PC_BLE_DRIVER_LOC=$SITE_PACKAGES/pc_ble_driver_py/lib/macos
-   BREW_PYTHON=/usr/local/Cellar/python@3.8/3.8.3_2/Frameworks/Python.framework/Versions/3.8/lib/libpython3.8.dylib
-
-   install_name_tool -change $SYSTEM_PYTHON $BREW_PYTHON $PC_BLE_DRIVER_LOC/_pc_ble_driver_sd_api_v2.so
-   install_name_tool -change $SYSTEM_PYTHON $BREW_PYTHON $PC_BLE_DRIVER_LOC/_pc_ble_driver_sd_api_v5.so
+Example shell script to do so (with more info) can be found here:
+`macos script`_
 
 Setting up Hardware
 ^^^^^^^^^^^^^^^^^^^
@@ -77,3 +67,4 @@ If things do not seem to be working, check out the :doc:`./troubleshooting` page
 
 
 .. _nRF Connect: https://www.nordicsemi.com/Software-and-tools/Development-Tools/nRF-Connect-for-desktop
+.. _macos script: https://github.com/ThomasGerstenberg/blatann/tree/master/blatann/examples

--- a/tools/macos_retarget_pc_ble_driver_py.sh
+++ b/tools/macos_retarget_pc_ble_driver_py.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+
+# Script to retarget the pc-ble-driver-py dependencies to a different python install.
+# The shared object in the library is linked against the system-installed python, which is not
+# ideal since people commonly use brew-installed python instead (or anaconda).
+#
+# This script should be run within the python environment you want to use,
+# and blatann + pc-ble-driver-py should already be pip-installed into the environment.
+#
+# NOTE: This will need to be run any time pc-ble-driver-py is installed or updated, even virtual environments.
+#       Easy test to see if it needs to be run: `import blatann` will fail
+
+# Python executable to use. Change this out if something other than python3 should be used
+PYTHON=python3
+
+# Get the location
+PYTHON_LOC=`which $PYTHON`
+
+if [[ -z $PYTHON_LOC ]]
+then
+	echo "ERROR: Unable to find python location"
+	exit -1
+fi
+
+echo "targeting python @ $PYTHON_LOC"
+echo
+
+# Ensure blatann and pc-ble-driver-py are already installed
+BLATANN=`$PYTHON -m pip list | grep blatann`
+PC_BLE_DRIVER_PY=`$PYTHON -m pip list | grep pc-ble-driver-py`
+
+if [[ -z $BLATANN ]]
+then
+	echo "ERROR: unable to find blatann install. Run 'pip install blatann' prior to running this script"
+	exit -1
+fi
+
+echo "found lib: $BLATANN"
+
+if [[ -z $PC_BLE_DRIVER_PY ]]
+then
+	echo "ERROR: unable to find pc-ble-driver-py install. Run 'pip install pc-ble-driver-py' prior to running this script"
+	exit -1
+fi
+
+echo "found lib: $PC_BLE_DRIVER_PY"
+
+# Get the location of pc-ble-driver-py by importing the lib and printing out its directory
+PC_BLE_DRIVER_LOC=`$PYTHON -c "import os, pc_ble_driver_py; print(os.path.dirname(pc_ble_driver_py.__file__))"`
+# For the python2.7 version change the path to 'lib/macos_osx/_pc_ble_driver_sd_api_v3.so'
+PC_BLE_DRIVER_LIB=$PC_BLE_DRIVER_LOC/lib/_nrf_ble_driver_sd_api_v5.so
+
+echo "pc-ble-driver location: $PC_BLE_DRIVER_LOC"
+echo "library to patch:       $PC_BLE_DRIVER_LIB"
+echo
+
+# Determine the location of the Python libraries for the target python and currently-linked python.
+# Output of otool -L is:
+# path/to/lib
+#    path/to/dependency1 (version compat info)
+#    path/to/dependency2 (version compat info)
+#    ...
+#
+# We need to find the Python.framework dependency so we can switch it out using install_name_tool
+#
+# Command breakdown:
+#    otool -L : Print out library dependencies (above)
+#    tail -n +2 : Skip the first line (path of the library itself), in case it also includes 'Python.framework'
+#    grep : Find the entry with the path to the Python framework dependency
+#    cut : Cut on spaces and take only the first part (the path)
+#    xargs : strip off whitespace from the otool output
+TARGET_LIB=`otool -L $PYTHON_LOC | tail -n +2 | grep Python.framework | cut -d " " -f 1 | xargs`
+CURRENT_LIB=`otool -L $PC_BLE_DRIVER_LIB | tail -n +2 | grep Python.framework | cut -d " " -f 1 | xargs`
+
+# Sanity-check both paths are found
+if [[ -z $TARGET_LIB || -z $CURRENT_LIB ]]
+then
+	echo "ERROR: unable to find paths in otool!"
+	exit -1
+fi
+
+echo "re-linking library"
+echo "old:    $CURRENT_LIB"
+echo "new:    $TARGET_LIB"
+echo
+
+# Change out the current lib with the target
+install_name_tool -change $CURRENT_LIB $TARGET_LIB $PC_BLE_DRIVER_LIB
+
+# Verify the change worked
+echo "testing that blatann can be imported..."
+if $PYTHON -c "import blatann"
+then
+	echo "Success!"
+else
+	echo "Re-target failed!"
+	exit -1
+fi


### PR DESCRIPTION
Replaces example in readme/docs with version that's fleshed out and should run as-is in most environments