### PR TITLE
Fix BasicGlucoseDatabase for Python 3

### DIFF
--- a/blatann/services/glucose/database.py
+++ b/blatann/services/glucose/database.py
@@ -86,9 +86,9 @@ class BasicGlucoseDatabase(IGlucoseDatabase):
             records = self._records[:]
 
         if min_seq_num is not None:
-            records = filter(lambda r: r.sequence_number >= min_seq_num, records)
+            records = [r for r in records if r.sequence_number >= min_seq_num]
         if max_seq_num is not None:
-            records = filter(lambda r: r.sequence_number <= max_seq_num, records)
+            records = [r for r in records if r.sequence_number <= max_seq_num]
         return records
 
     def delete_records(self, min_seq_num=None, max_seq_num=None):


### PR DESCRIPTION
In Python 2, `filter(...)` returns a list. https://docs.python.org/2/library/functions.html#filter
In Python 3, `filter(...)` returns an Iterable. https://docs.python.org/3/library/functions.html#filter

This pull request updates `BasicGlucoseDatabase._get_records_in_range(...)` so that it returns a list instead of an Iterable. 