### PR TITLE
Connection Parameter Update Event

### DIFF
--- a/blatann/device.py
+++ b/blatann/device.py
@@ -274,9 +274,9 @@ class BleDevice(NrfDriverObserver):
         either times out or reports the newly connected peer
 
         :param peer_address: The address of the peer to connect to
-        :type peer_address: peer.PeerAddress
+        :type peer_address: blatann.gap.gap_types.PeerAddress
         :param connection_params: Optional connection parameters to use. If not specified, uses the set default
-        :type connection_params: peer.ConnectionParameters
+        :type connection_params: blatann.gap.gap_types.ConnectionParameters
         :return: A Waitable which can be used to wait until the connection is successful or times out. Waitable returns
                  a peer.Peripheral object
         """

--- a/blatann/event_args.py
+++ b/blatann/event_args.py
@@ -1,6 +1,7 @@
 from typing import TypeVar, Generic, Callable, Union
 from enum import Enum, auto
 
+from blatann.gap.gap_types import ActiveConnectionParameters
 from blatann.utils import repr_format
 
 from blatann.nrf.nrf_types import BLEGattStatusCode as GattStatusCode
@@ -80,6 +81,17 @@ class PhyUpdatedEventArgs(EventArgs):
     def __init__(self, status, phy_channel):
         self.status = status
         self.phy_channel = phy_channel
+
+
+class ConnectionParametersUpdatedEventArgs(EventArgs):
+    """
+    Event arguments for when connection parameters between peers are updated
+    """
+    def __init__(self, active_connection_parameters: ActiveConnectionParameters):
+        """
+        :param active_connection_parameters: The newly configured connection parameters
+        """
+        self.active_connection_parameters = active_connection_parameters
 
 
 # SMP Event Args

--- a/blatann/event_args.py
+++ b/blatann/event_args.py
@@ -87,11 +87,11 @@ class ConnectionParametersUpdatedEventArgs(EventArgs):
     """
     Event arguments for when connection parameters between peers are updated
     """
-    def __init__(self, active_connection_parameters: ActiveConnectionParameters):
+    def __init__(self, active_connection_params: ActiveConnectionParameters):
         """
-        :param active_connection_parameters: The newly configured connection parameters
+        :param active_connection_params: The newly configured connection parameters
         """
-        self.active_connection_parameters = active_connection_parameters
+        self.active_connection_params = active_connection_params
 
 
 # SMP Event Args

--- a/blatann/examples/peripheral.py
+++ b/blatann/examples/peripheral.py
@@ -236,6 +236,10 @@ class CountingCharacteristicThread(object):
         self._stopped.set()
 
 
+def on_conn_params_updated(peer, event_args):
+    print(f"Conn params updated to {event_args.active_connection_params}")
+
+
 def main(serial_port):
     # Create and open the device
     ble_device = BleDevice(serial_port)
@@ -253,6 +257,7 @@ def main(serial_port):
     ble_device.client.security.on_passkey_display_required.register(on_passkey_display)
     ble_device.client.security.on_passkey_required.register(on_passkey_entry)
     ble_device.client.security.on_security_level_changed.register(on_security_level_changed)
+    ble_device.client.on_connection_parameters_updated.register(on_conn_params_updated)
 
     # Create and add the math service
     service = ble_device.database.add_service(constants.MATH_SERVICE_UUID)
@@ -301,4 +306,4 @@ def main(serial_port):
     
 
 if __name__ == '__main__':
-    main("COM13")
+    main("COM4")

--- a/blatann/gap/__init__.py
+++ b/blatann/gap/__init__.py
@@ -1,10 +1,12 @@
-from blatann.nrf.nrf_types import BLEHci as _BLEHci
+import enum
+from blatann.nrf import nrf_events, nrf_types
 from blatann.gap.smp import (SecurityStatus, IoCapabilities, AuthenticationKeyType,
                              SecurityParameters, PairingPolicy, SecurityLevel)
 from blatann.gap.scanning import ScanParameters
 from blatann.gap.advertising import AdvertisingData, AdvertisingFlags
 
-HciStatus = _BLEHci
+
+HciStatus = nrf_types.BLEHci
 
 """
 The default link-layer packet size used when a connection is established

--- a/blatann/gap/bond_db.py
+++ b/blatann/gap/bond_db.py
@@ -1,7 +1,7 @@
 import typing
 
 if typing.TYPE_CHECKING:
-    from blatann.peer import PeerAddress
+    from blatann.gap.gap_types import PeerAddress
 
 
 class BondingData(object):

--- a/blatann/gap/gap_types.py
+++ b/blatann/gap/gap_types.py
@@ -27,13 +27,12 @@ class ConnectionParameters(nrf_events.BLEGapConnParams):
         super(ConnectionParameters, self).__init__(min_conn_interval_ms, max_conn_interval_ms, timeout_ms, slave_latency)
         self.validate()
 
-    def validate(self):
-        nrf_types.conn_interval_range.validate(self.min_conn_interval_ms)
-        nrf_types.conn_interval_range.validate(self.max_conn_interval_ms)
-        nrf_types.conn_timeout_range.validate(self.conn_sup_timeout_ms)
-        if self.min_conn_interval_ms > self.max_conn_interval_ms:
-            raise ValueError(f"Minimum connection interval must be <= max connection interval "
-                             f"(Min: {self.min_conn_interval_ms} Max: {self.max_conn_interval_ms}")
+    def __str__(self):
+        return (f"ConnectionParams([{self.min_conn_interval_ms}-{self.max_conn_interval_ms}] ms, "
+                f"timeout: {self.conn_sup_timeout_ms} ms, latency: {self.slave_latency}")
+
+    def __repr__(self):
+        return str(self)
 
 
 class ActiveConnectionParameters(object):
@@ -52,6 +51,13 @@ class ActiveConnectionParameters(object):
 
     def __str__(self):
         return f"ConnectionParams({self._interval_ms}ms/{self._slave_latency}/{self._timeout_ms}ms)"
+
+    def __eq__(self, other):
+        if not isinstance(other, ActiveConnectionParameters):
+            return False
+        return (self._interval_ms == other._interval_ms and
+                self._slave_latency == other._slave_latency and
+                self._timeout_ms == other._timeout_ms)
 
     @property
     def interval_ms(self) -> float:

--- a/blatann/gap/gap_types.py
+++ b/blatann/gap/gap_types.py
@@ -1,0 +1,82 @@
+import enum
+from blatann.nrf import nrf_events, nrf_types
+
+
+class Phy(enum.IntFlag):
+    """
+    The supported PHYs
+
+    .. note:: Coded PHY is currently not supported (hardware limitation)
+    """
+    auto = int(nrf_events.BLEGapPhy.auto)          #: Automatically select the PHY based on what's supported
+    one_mbps = int(nrf_events.BLEGapPhy.one_mbps)  #: 1 Mbps PHY
+    two_mbps = int(nrf_events.BLEGapPhy.two_mbps)  #: 2 Mbps PHY
+    # NOT SUPPORTED coded = int(nrf_events.BLEGapPhy.coded)
+
+
+class PeerAddress(nrf_events.BLEGapAddr):
+    pass
+
+
+class ConnectionParameters(nrf_events.BLEGapConnParams):
+    """
+    Represents the connection parameters that are sent during negotiation. This includes
+    the preferred min/max interval range, timeout, and slave latency
+    """
+    def __init__(self, min_conn_interval_ms, max_conn_interval_ms, timeout_ms, slave_latency=0):
+        super(ConnectionParameters, self).__init__(min_conn_interval_ms, max_conn_interval_ms, timeout_ms, slave_latency)
+        self.validate()
+
+    def validate(self):
+        nrf_types.conn_interval_range.validate(self.min_conn_interval_ms)
+        nrf_types.conn_interval_range.validate(self.max_conn_interval_ms)
+        nrf_types.conn_timeout_range.validate(self.conn_sup_timeout_ms)
+        if self.min_conn_interval_ms > self.max_conn_interval_ms:
+            raise ValueError(f"Minimum connection interval must be <= max connection interval "
+                             f"(Min: {self.min_conn_interval_ms} Max: {self.max_conn_interval_ms}")
+
+
+class ActiveConnectionParameters(object):
+    """
+    Represents the connection parameters that are currently in use with a peer device.
+    This is similar to ConnectionParameters with the sole difference being
+    the connection interval is not a min/max range but a single number
+    """
+    def __init__(self, conn_params: ConnectionParameters):
+        self._interval_ms = conn_params.min_conn_interval_ms
+        self._timeout_ms = conn_params.conn_sup_timeout_ms
+        self._slave_latency = conn_params.slave_latency
+
+    def __repr__(self):
+        return str(self)
+
+    def __str__(self):
+        return f"ConnectionParams({self._interval_ms}ms/{self._slave_latency}/{self._timeout_ms}ms)"
+
+    @property
+    def interval_ms(self) -> float:
+        """
+        **Read Only**
+
+        The connection interval, in milliseconds
+        """
+        return self._interval_ms
+
+    @property
+    def timeout_ms(self) -> float:
+        """
+        **Read Only**
+
+        The connection timeout, in milliseconds
+        """
+        return self._timeout_ms
+
+    @property
+    def slave_latency(self) -> int:
+        """
+        **Read Only**
+
+        The slave latency (the number of connection intervals the slave is allowed to skip before being
+        required to respond)
+        """
+        return self._slave_latency

--- a/blatann/nrf/nrf_types/gap.py
+++ b/blatann/nrf/nrf_types/gap.py
@@ -121,6 +121,14 @@ class BLEGapConnParams(object):
         self.conn_sup_timeout_ms = conn_sup_timeout_ms
         self.slave_latency = slave_latency
 
+    def validate(self):
+        conn_interval_range.validate(self.min_conn_interval_ms)
+        conn_interval_range.validate(self.max_conn_interval_ms)
+        conn_timeout_range.validate(self.conn_sup_timeout_ms)
+        if self.min_conn_interval_ms > self.max_conn_interval_ms:
+            raise ValueError(f"Minimum connection interval must be <= max connection interval "
+                             f"(Min: {self.min_conn_interval_ms} Max: {self.max_conn_interval_ms}")
+
     @classmethod
     def from_c(cls, conn_params):
         return cls(min_conn_interval_ms=util.units_to_msec(conn_params.min_conn_interval,
@@ -142,6 +150,9 @@ class BLEGapConnParams(object):
         conn_params.slave_latency = self.slave_latency
 
         return conn_params
+
+    def __repr__(self):
+        return str(self)
 
     def __str__(self):
         return "{}(interval: [{!r}-{!r}] ms, timeout: {!r} ms, latency: {!r})".format(self.__class__.__name__,

--- a/blatann/peer.py
+++ b/blatann/peer.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 import logging
 import threading
 import enum
+from typing import Optional
 
 from blatann.event_type import EventSource, Event
 from blatann.gap import smp
+from blatann.gap.gap_types import Phy, PeerAddress, ConnectionParameters, ActiveConnectionParameters
 from blatann.gatt import gattc, service_discovery, MTU_SIZE_DEFAULT, MTU_SIZE_MINIMUM, DLE_MAX, DLE_MIN, DLE_OVERHEAD
 from blatann.nrf import nrf_events
 from blatann.nrf.nrf_types.enums import BLE_CONN_HANDLE_INVALID
@@ -24,87 +26,6 @@ class PeerState(enum.Enum):
     DISCONNECTED = 0  #: Peer is disconnected
     CONNECTING = 1    #: Peer is in the process of connecting
     CONNECTED = 2     #: Peer is connected
-
-
-class Phy(enum.IntFlag):
-    """
-    The supported PHYs
-
-    .. note:: Coded PHY is currently not supported (hardware limitation)
-    """
-    auto = int(nrf_events.BLEGapPhy.auto)          #: Automatically select the PHY based on what's supported
-    one_mbps = int(nrf_events.BLEGapPhy.one_mbps)  #: 1 Mbps PHY
-    two_mbps = int(nrf_events.BLEGapPhy.two_mbps)  #: 2 Mbps PHY
-
-    # NOT SUPPORTED coded = int(nrf_events.BLEGapPhy.coded)
-
-
-class PeerAddress(nrf_events.BLEGapAddr):
-    pass
-
-
-class ConnectionParameters(nrf_events.BLEGapConnParams):
-    """
-    Represents the connection parameters that are sent during negotiation. This includes
-    the preferred min/max interval range, timeout, and slave latency
-    """
-    def __init__(self, min_conn_interval_ms, max_conn_interval_ms, timeout_ms, slave_latency=0):
-        super(ConnectionParameters, self).__init__(min_conn_interval_ms, max_conn_interval_ms, timeout_ms, slave_latency)
-        self.validate()
-
-    def validate(self):
-        conn_interval_range.validate(self.min_conn_interval_ms)
-        conn_interval_range.validate(self.max_conn_interval_ms)
-        conn_timeout_range.validate(self.conn_sup_timeout_ms)
-        if self.min_conn_interval_ms > self.max_conn_interval_ms:
-            raise ValueError(f"Minimum connection interval must be <= max connection interval "
-                             f"(Min: {self.min_conn_interval_ms} Max: {self.max_conn_interval_ms}")
-
-
-class ActiveConnectionParameters(object):
-    """
-    Represents the connection parameters that are currently in use with a peer device.
-    This is similar to ConnectionParameters with the sole difference being
-    the connection interval is not a min/max range but a single number
-    """
-    def __init__(self, conn_params: ConnectionParameters):
-        self._interval_ms = conn_params.min_conn_interval_ms
-        self._timeout_ms = conn_params.conn_sup_timeout_ms
-        self._slave_latency = conn_params.slave_latency
-
-    def __repr__(self):
-        return str(self)
-
-    def __str__(self):
-        return f"ConnectionParams({self._interval_ms}ms/{self._slave_latency}/{self._timeout_ms}ms)"
-
-    @property
-    def interval_ms(self) -> float:
-        """
-        **Read Only**
-
-        The connection interval, in milliseconds
-        """
-        return self._interval_ms
-
-    @property
-    def timeout_ms(self) -> float:
-        """
-        **Read Only**
-
-        The connection timeout, in milliseconds
-        """
-        return self._timeout_ms
-
-    @property
-    def slave_latency(self) -> int:
-        """
-        **Read Only**
-
-        The slave latency (the number of connection intervals the slave is allowed to skip before being
-        required to respond)
-        """
-        return self._slave_latency
 
 
 DEFAULT_CONNECTION_PARAMS = ConnectionParameters(15, 30, 4000, 0)
@@ -138,6 +59,7 @@ class Peer(object):
         self._on_disconnect = EventSource("On Disconnect", logger)
         self._on_mtu_exchange_complete = EventSource("On MTU Exchange Complete", logger)
         self._on_mtu_size_updated = EventSource("On MTU Size Updated", logger)
+        self._on_conn_params_updated = EventSource("On Connection Parameters Updated", logger)
         self._on_data_length_updated = EventSource("On Data Length Updated", logger)
         self._on_phy_updated = EventSource("On Phy Updated", logger)
         self._mtu_size = MTU_SIZE_DEFAULT
@@ -162,7 +84,7 @@ class Peer(object):
     def name(self) -> str:
         """
         The name of the peer, if known. This property is for the user's benefit to name certain connections.
-        The name is is also saved in the case that the peer is subsequently bonded to and can be looked up that way
+        The name is also saved in the case that the peer is subsequently bonded to and can be looked up that way
         in the bond database
 
         .. note:: For central peers this name is unknown unless set by the setter.
@@ -218,7 +140,8 @@ class Peer(object):
         """
         **Read Only**
 
-        Gets if the peer has bonding information stored in the bond database (the peer was bonded to in a previous connection)
+        Gets if the peer has bonding information stored in the bond database
+        (the peer was bonded to in a previous connection)
         """
         return self.security.is_previously_bonded
 
@@ -263,7 +186,8 @@ class Peer(object):
     def preferred_mtu_size(self) -> int:
         """
         The user-set preferred MTU size. Defaults to the Bluetooth default MTU size (23).
-        This is the value that will be negotiated during an MTU Exchange but is not guaranteed in the case that the peer has a smaller MTU
+        This is the value that will be negotiated during an MTU Exchange
+        but is not guaranteed in the case that the peer has a smaller MTU
 
         :getter: Gets the preferred MTU size that was configured
         :setter: Sets the preferred MTU size to use for MTU exchanges
@@ -346,6 +270,13 @@ class Peer(object):
         return self._on_mtu_size_updated
 
     @property
+    def on_connection_parameters_updated(self) -> Event[Peer, ConnectionParametersUpdatedEventArgs]:
+        """
+        Event generated when the connection parameters with this peer is updated
+        """
+        return self._on_conn_params_updated
+
+    @property
     def on_data_length_updated(self) -> Event[Peer, DataLengthUpdatedEventArgs]:
         """
         Event generated when the link layer data length has been updated
@@ -388,29 +319,38 @@ class Peer(object):
                                   min_connection_interval_ms: float,
                                   max_connection_interval_ms: float,
                                   connection_timeout_ms: int,
-                                  slave_latency=0):
+                                  slave_latency=0) -> Optional[EventWaitable[Peer, ConnectionParametersUpdatedEventArgs]]:
         """
         Sets the connection parameters for the peer and starts the connection parameter update process (if connected)
 
-        .. note:: Connection interval values should be a multiple of 1.25ms since that is the granularity allowed in the Bluetooth specification.
-           Any non-multiples will be rounded down to the nearest 1.25ms.
+        .. note:: Connection interval values should be a multiple of 1.25ms since that is the granularity allowed
+           in the Bluetooth specification. Any non-multiples will be rounded down to the nearest 1.25ms.
            Additionally, the connection timeout has a granularity of 10 milliseconds and will also be rounded as such.
 
         :param min_connection_interval_ms: The minimum acceptable connection interval, in milliseconds
         :param max_connection_interval_ms: The maximum acceptable connection interval, in milliseconds
         :param connection_timeout_ms: The connection timeout, in milliseconds
-        :param slave_latency: The slave latency allowed, which regulates how many connection intervals the peripheral is allowed to skip before responding
+        :param slave_latency: The slave latency allowed, which regulates how many connection intervals
+                              the peripheral is allowed to skip before responding
+
+        :return: If the peer is connected, this will return a waitable that will trigger when the update completes
+                 with the new connection parameters. If disconnected, returns None
         """
         self._preferred_connection_params = ConnectionParameters(min_connection_interval_ms, max_connection_interval_ms,
                                                                  connection_timeout_ms, slave_latency)
         if self.connected:
-            self.update_connection_parameters()
+            return self.update_connection_parameters()
+        return None
 
-    def update_connection_parameters(self):
+    def update_connection_parameters(self) -> EventWaitable[Peer, ConnectionParametersUpdatedEventArgs]:
         """
-        Starts the process to re-negotiate the connection parameters using the previously-set connection parameters
+        Starts the process to re-negotiate the connection parameters
+        using the configured preferred connection parameters
+
+        :return: A waitable that will trigger when the connection parameters are updated
         """
         self._ble_device.ble_driver.ble_gap_conn_param_update(self.conn_handle, self._preferred_connection_params)
+        return EventWaitable(self._on_conn_params_updated)
 
     def exchange_mtu(self, mtu_size=None) -> EventWaitable[Peer, MtuSizeUpdatedEventArgs]:
         """
@@ -499,7 +439,9 @@ class Peer(object):
         self._current_connection_params = ActiveConnectionParameters(connection_params)
 
         self._ble_device.ble_driver.event_subscribe(self._on_disconnect_event, nrf_events.GapEvtDisconnected)
-        self.driver_event_subscribe(self._on_connection_param_update, nrf_events.GapEvtConnParamUpdate, nrf_events.GapEvtConnParamUpdateRequest)
+        self.driver_event_subscribe(self._on_connection_param_update,
+                                    nrf_events.GapEvtConnParamUpdate,
+                                    nrf_events.GapEvtConnParamUpdateRequest)
         self.driver_event_subscribe(self._on_mtu_exchange_request, nrf_events.GattsEvtExchangeMtuRequest)
         self.driver_event_subscribe(self._on_mtu_exchange_response, nrf_events.GattcEvtMtuExchangeResponse)
         self.driver_event_subscribe(self._on_data_length_update_request, nrf_events.GapEvtDataLengthUpdateRequest)
@@ -546,10 +488,7 @@ class Peer(object):
     Private Methods
     """
 
-    def _on_disconnect_event(self, driver, event):
-        """
-        :type event: nrf_events.GapEvtDisconnected
-        """
+    def _on_disconnect_event(self, driver, event: nrf_events.GapEvtDisconnected):
         if not self.connected or self.conn_handle != event.conn_handle:
             return
         self.conn_handle = BLE_CONN_HANDLE_INVALID
@@ -564,10 +503,7 @@ class Peer(object):
         self._ble_device.ble_driver.event_unsubscribe(self._on_disconnect_event)
         self._ble_device.ble_driver.event_unsubscribe(self._on_connection_param_update)
 
-    def _on_connection_param_update(self, driver, event):
-        """
-        :type event: nrf_events.GapEvtConnParamUpdate
-        """
+    def _on_connection_param_update(self, driver, event: nrf_events.GapEvtConnParamUpdate):
         if not self.connected or self.conn_handle != event.conn_handle:
             return
         if isinstance(event, nrf_events.GapEvtConnParamUpdateRequest):
@@ -576,6 +512,7 @@ class Peer(object):
         else:
             logger.debug("[{}] Updated to {}".format(self.conn_handle, event.conn_params))
             self._current_connection_params = ActiveConnectionParameters(event.conn_params)
+            self._on_conn_params_updated.notify(self, ConnectionParametersUpdatedEventArgs(self._current_connection_params))
 
     def _validate_mtu_size(self, mtu_size):
         if mtu_size < MTU_SIZE_MINIMUM:
@@ -629,7 +566,8 @@ class Peer(object):
 
 class Peripheral(Peer):
     """
-    Object which represents a BLE-connected device that is acting as a peripheral/server (local device is client/central)
+    Object which represents a BLE-connected device that is acting as a peripheral/server
+    (local device is client/central)
     """
     def __init__(self, ble_device, peer_address,
                  connection_params=DEFAULT_CONNECTION_PARAMS,
@@ -644,7 +582,8 @@ class Peripheral(Peer):
 
 class Client(Peer):
     """
-    Object which represents a BLE-connected device that is acting as a client/central (local device is peripheral/server)
+    Object which represents a BLE-connected device that is acting as a client/central
+    (local device is peripheral/server)
     """
     def __init__(self, ble_device,
                  connection_params=DEFAULT_CONNECTION_PARAMS,

--- a/blatann/peer.py
+++ b/blatann/peer.py
@@ -592,8 +592,9 @@ class Peripheral(Peer):
         """
         Sets the connection parameter request handler to a callback that accepts any connection parameter
         update requests received from the peripheral. This is the same as calling ``set_conn_param_request_handler``
-        with a callback that simply returns the connection parameters passed in
-        :return:
+        with a callback that simply returns the connection parameters passed in.
+
+        This is the default functionality.
         """
         self._conn_param_update_request_handler = self._accept_all_conn_param_requests
 

--- a/blatann/waitables/waitable.py
+++ b/blatann/waitables/waitable.py
@@ -29,16 +29,21 @@ class Waitable(object):
         :return: The result of the asynchronous operation
         :raises: TimeoutError
         """
+        did_timeout = False
         try:
             results = self._queue.get(timeout=timeout)
             if len(results) == 1:
                 return results[0]
             return results
         except queue.Empty:
+            did_timeout = True
+
+        if did_timeout:
             self._on_timeout()
             if exception_on_timeout:
                 raise TimeoutError("Timed out waiting for event to occur. "
                                    "Waitable type: {}".format(self.__class__.__name__))
+
         if self._n_args == 1:
             return None
         return [None] * self._n_args

--- a/tests/integrated/helpers.py
+++ b/tests/integrated/helpers.py
@@ -25,7 +25,7 @@ class CentralConn(object):
 
 
 def setup_connection(periph_conn: PeriphConn, central_conn: CentralConn,
-                     conn_params=None):
+                     conn_params=None, discover_services=True):
     if conn_params is None:
         conn_params = ConnectionParameters(conn_interval_range.min, conn_interval_range.min, 4000)
     periph_conn.dev.set_default_peripheral_connection_params(conn_params.max_conn_interval_ms,
@@ -38,9 +38,11 @@ def setup_connection(periph_conn: PeriphConn, central_conn: CentralConn,
     # Once central reports its connected wait for the peripheral to be connected before continuing
     waitable = periph_conn.dev.advertiser.start(timeout_sec=30)
     central_conn.peer = central_conn.dev.connect(adv_addr, conn_params).wait(10)
+
     periph_conn.peer = waitable.wait(10)
 
-    central_conn.peer.discover_services().wait(10)
+    if discover_services:
+        central_conn.peer.discover_services().wait(10)
 
 
 def rand_bytes(n):

--- a/tests/integrated/test_gap.py
+++ b/tests/integrated/test_gap.py
@@ -1,0 +1,82 @@
+import queue
+import unittest
+
+from blatann import BleDevice
+from blatann.gap.gap_types import ConnectionParameters
+from blatann.waitables import EventWaitable
+
+from tests.integrated.base import BlatannTestCase, TestParams, long_running
+from tests.integrated.helpers import PeriphConn, CentralConn, setup_connection
+
+
+class TestGap(BlatannTestCase):
+    periph_conn = PeriphConn()
+    central_conn = CentralConn()
+    periph: BleDevice
+    central: BleDevice
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        super(TestGap, cls).setUpClass()
+        cls.periph = cls.dev1
+        cls.periph_conn.dev = cls.dev1
+        cls.central = cls.dev2
+        cls.central_conn.dev = cls.dev2
+
+    def tearDown(self) -> None:
+        if self.central_conn.peer.connected:
+            self.central_conn.peer.disconnect().wait(10)
+
+    def _run_conn_param_test(self, central_initiated, central_reject=False):
+        conn_event_queue = queue.Queue()
+        default_conn_params = (10, 30, 4000)
+        update_conn_params = (50, 70, 6000)
+        # Setup connection with default conn parameters
+        initial_conn_params = ConnectionParameters(*default_conn_params)
+        self.periph.set_default_peripheral_connection_params(*update_conn_params)
+        self.periph.client.set_connection_parameters(*update_conn_params)
+        setup_connection(self.periph_conn, self.central_conn, initial_conn_params, discover_services=False)
+
+        # Verify connection was successful
+        self.assertTrue(self.periph_conn.peer.connected)
+        self.assertTrue(self.central_conn.peer.connected)
+
+        if central_reject:
+            self.central_conn.peer.reject_conn_param_requests()
+        else:
+            self.central_conn.peer.accept_all_conn_param_requests()
+
+        # Determine conn param update initiator/receiver
+        initiator = self.central_conn.peer if central_initiated else self.periph_conn.peer
+        receiver = self.periph_conn.peer if central_initiated else self.central_conn.peer
+
+        # Create a waitable for the conn param update on the receiver side
+        receiver_waitable = EventWaitable(receiver.on_connection_parameters_updated)
+        # Initiate conn param update procedure, wait for result
+        _, initiator_result = initiator.set_connection_parameters(*update_conn_params).wait(3)
+        # Get event on receiver side
+
+        # If central rejection is configured, there shouldn't be an event received on the receiver (central)
+        if not central_reject:
+            _, receiver_result = receiver_waitable.wait(3)
+            receiver_params = receiver_result.active_connection_params
+        else:
+            _, receiver_result = receiver_waitable.wait(3, exception_on_timeout=False)
+            self.assertIsNone(receiver_result)
+            receiver_params = receiver.active_connection_params
+
+        initiator_params = initiator_result.active_connection_params
+
+        # Make sure everything matches
+        self.assertEqual(receiver_params, initiator_params)
+        self.assertEqual(receiver_params, self.central_conn.peer.active_connection_params)
+        self.assertEqual(receiver_params, self.periph_conn.peer.active_connection_params)
+
+    def test_connection_parameters_peripheral_initiated_central_accepts(self):
+        self._run_conn_param_test(central_initiated=False)
+
+    def test_connection_parameters_peripheral_initiated_central_rejects(self):
+        self._run_conn_param_test(central_initiated=False, central_reject=True)
+
+    def test_connection_parameters_central_initiated(self):
+        self._run_conn_param_test(central_initiated=True)


### PR DESCRIPTION
Addresses #102

- Adds event that triggers when connection parameters are updated
- Adds ability to configure how a central device handles peripheral-initiated connection parameter update requests
  - Accept all, reject all, or set custom handler
  - Default functionality is to accept all peripheral requests
- Integrated tests for connection parameter update sequences

Other changes:
- Moved some class definitions from `peer.py` into new `gap_types.py`, required to address circular dependency. Shouldn't be breaking due to the classes still being imported in `peer.py`
- Removed the "exception in exception" when a timeout is triggered from `EventWaitable.wait()`