### PR TITLE
Support anonymous advertising packets

### DIFF
--- a/blatann/gap/advertise_data.py
+++ b/blatann/gap/advertise_data.py
@@ -1,7 +1,7 @@
 import time
 from typing import Iterable, List, Dict, Union, Optional, Tuple
 import logging
-from blatann.nrf import nrf_types
+from blatann.nrf import nrf_types, nrf_events
 from blatann import uuid, exceptions
 
 
@@ -374,11 +374,10 @@ class ScanReportCollection(object):
         self._all_scans = []
         self._scans_by_peer_address = {}
 
-    def update(self, adv_report) -> ScanReport:
+    def update(self, adv_report: nrf_events.GapEvtAdvReport) -> ScanReport:
         """
         Used internally to update the collection with a new advertising report received
 
-        :type adv_report: nrf_events.GapEvtAdvReport
         :return: The Scan Report created from the advertising report
         """
         scan_entry = ScanReport(adv_report)
@@ -387,6 +386,6 @@ class ScanReportCollection(object):
         self._all_scans.append(scan_entry)
         if adv_report.peer_addr in self._scans_by_peer_address.keys():
             self._scans_by_peer_address[adv_report.peer_addr].update(adv_report)
-        else:
+        elif adv_report.peer_addr.addr_type != nrf_types.BLEGapAddrTypes.anonymous:
             self._scans_by_peer_address[adv_report.peer_addr] = ScanReport(adv_report)
         return scan_entry

--- a/blatann/nrf/nrf_types/gap.py
+++ b/blatann/nrf/nrf_types/gap.py
@@ -167,6 +167,7 @@ class BLEGapAddrTypes(IntEnum):
     random_static = int(driver.BLE_GAP_ADDR_TYPE_RANDOM_STATIC)
     random_private_resolvable = int(driver.BLE_GAP_ADDR_TYPE_RANDOM_PRIVATE_RESOLVABLE)
     random_private_non_resolvable = int(driver.BLE_GAP_ADDR_TYPE_RANDOM_PRIVATE_NON_RESOLVABLE)
+    anonymous = 127  # This isn't defined in the headers for Softdevice v5 and was added in v6
 
 
 class BLEGapAddr(object):
@@ -217,6 +218,8 @@ class BLEGapAddr(object):
             return 'res'
         elif self.addr_type == BLEGapAddrTypes.random_static:
             return 'static'
+        elif self.addr_type == BLEGapAddrTypes.anonymous:
+            return 'anonymous'
         else:
             return 'err'
 
@@ -239,7 +242,8 @@ class BLEGapAddr(object):
             BLEGapAddrTypes.public: "p",
             BLEGapAddrTypes.random_static: "s",
             BLEGapAddrTypes.random_private_resolvable: "r",
-            BLEGapAddrTypes.random_private_non_resolvable: "n"
+            BLEGapAddrTypes.random_private_non_resolvable: "n",
+            BLEGapAddrTypes.anonymous: "a"
         }[self.addr_type]
 
     def __str__(self):


### PR DESCRIPTION
This feature isn't supported until SoftDevice v6, but #105 reports seeing value 127 (defined [here](https://github.com/NordicSemiconductor/pc-ble-driver/blob/master/include/sd_api_v6/ble_gap.h#L209) in v6)