### PR TITLE
Fix Timed_out spelling

### DIFF
--- a/blatann/gatt/managers.py
+++ b/blatann/gatt/managers.py
@@ -110,7 +110,7 @@ class _ReadWriteManager(QueuedTasksManagerBase[Union[_ReadTask, _WriteTask]]):
         self._clear_all(GattOperationCompleteReason.SERVER_DISCONNECTED)
 
     def _on_timeout(self, sender, event_args):
-        self._clear_all(GattOperationCompleteReason.TIMEOUT)
+        self._clear_all(GattOperationCompleteReason.TIMED_OUT)
 
     def _read_complete(self, sender, event_args):
         """


### PR DESCRIPTION
Fix one `GattOperationCompleteReason.TIMEOUT` left in the code