### PR TITLE
Replaces the default Bond DB format from pkl to json

### DIFF
--- a/.idea/blatann.iml
+++ b/.idea/blatann.iml
@@ -5,8 +5,9 @@
       <excludeFolder url="file://$MODULE_DIR$/blatann.egg-info" />
       <excludeFolder url="file://$MODULE_DIR$/build" />
       <excludeFolder url="file://$MODULE_DIR$/dist" />
+      <excludeFolder url="file://$MODULE_DIR$/venv" />
     </content>
-    <orderEntry type="jdk" jdkName="Python 3.8" jdkType="Python SDK" />
+    <orderEntry type="jdk" jdkName="Python 3.10 (blatann)" jdkType="Python SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
   <component name="PackageRequirementsSettings">

--- a/blatann/gap/bond_db.py
+++ b/blatann/gap/bond_db.py
@@ -1,27 +1,122 @@
+from __future__ import annotations
 import typing
+import logging
+
+from blatann.gap import smp_crypto
+from blatann.nrf.nrf_types import (
+    BLEGapAddr, BLEGapAddrTypes, BLEGapEncryptKey, BLEGapIdKey, BLEGapSignKey, BLEGapSecKeyset, BLEGapMasterId
+)
 
 if typing.TYPE_CHECKING:
     from blatann.gap.gap_types import PeerAddress
 
 
+logger = logging.getLogger(__name__)
+
+
 class BondingData(object):
-    def __init__(self, bonding_keyset):
-        """
-        :type bonding_keyset: blatann.nrf.nrf_types.smp.BLEGapSecKeyset
-        """
-        self.own_ltk = bonding_keyset.own_keys.enc_key
-        self.peer_ltk = bonding_keyset.peer_keys.enc_key
-        self.peer_id = bonding_keyset.peer_keys.id_key
-        self.peer_sign = bonding_keyset.peer_keys.sign_key
+    def __init__(self, own_ltk: BLEGapEncryptKey, peer_ltk: BLEGapEncryptKey,
+                 peer_id: BLEGapIdKey, peer_sign: BLEGapSignKey):
+        self.own_ltk = own_ltk
+        self.peer_ltk = peer_ltk
+        self.peer_id = peer_id
+        self.peer_sign = peer_sign
+
+    @classmethod
+    def from_keyset(cls, bonding_keyset: BLEGapSecKeyset):
+        return cls(
+            bonding_keyset.own_keys.enc_key,
+            bonding_keyset.peer_keys.enc_key,
+            bonding_keyset.peer_keys.id_key,
+            bonding_keyset.peer_keys.sign_key
+        )
+
+    def to_dict(self):
+        return {
+            "own_ltk": self.own_ltk.to_dict(),
+            "peer_ltk": self.peer_ltk.to_dict(),
+            "peer_id": self.peer_id.to_dict(),
+            "peer_sign": self.peer_sign.to_dict()
+        }
+
+    @classmethod
+    def from_dict(cls, data):
+        own_ltk = BLEGapEncryptKey.from_dict(data["own_ltk"])
+        peer_ltk = BLEGapEncryptKey.from_dict(data["peer_ltk"])
+        peer_id = BLEGapIdKey.from_dict(data["peer_id"])
+        peer_sign = BLEGapSignKey.from_dict(data["peer_sign"])
+        return cls(own_ltk, peer_ltk, peer_id, peer_sign)
 
 
 class BondDbEntry(object):
     def __init__(self, entry_id=0):
         self.id = entry_id
+        self.own_addr: PeerAddress = None
         self.peer_addr: PeerAddress = None
         self.peer_is_client: bool = False
         self.bonding_data: BondingData = None
         self.name = ""
+
+    def matches_peer(self, own_address: PeerAddress,
+                     peer_address: PeerAddress,
+                     peer_is_client: bool,
+                     master_id: BLEGapMasterId = None) -> bool:
+        # Wrong role
+        if peer_is_client != self.peer_is_client:
+            return False
+        # Entry has own address and doesn't match
+        if self.own_addr is not None and self.own_addr != own_address:
+            return False
+
+        if self.peer_address_matches_or_resolves(peer_address):
+            # If the bonding data is LESC, always return it.
+            # Otherwise, if a master ID is provided to match against, it should be used
+            if self.bonding_data.own_ltk.enc_info.lesc or not master_id:
+                return True
+
+        # Check master IDs
+        if master_id:
+            if self.bonding_data.own_ltk.master_id == master_id:
+                logger.debug("Found matching record with own master ID")
+                return True
+            if self.bonding_data.peer_ltk.master_id == master_id:
+                logger.debug("Found matching record with peer master ID")
+                return True
+        return False
+
+    def peer_address_matches_or_resolves(self, peer_address: PeerAddress) -> bool:
+        # Unresolvable, cannot match
+        if peer_address.addr_type == BLEGapAddrTypes.random_private_non_resolvable:
+            return False
+
+        # If peer address is public or random static, check directly if they match (no IRK needed)
+        if peer_address.addr_type in [BLEGapAddrTypes.random_static, BLEGapAddrTypes.public]:
+            if self.peer_addr == peer_address:
+                return True
+        elif smp_crypto.private_address_resolves(peer_address, self.bonding_data.peer_id.irk):
+            logger.info("Resolved Peer address to {}".format(self.peer_addr))
+            return True
+        return False
+
+    def to_dict(self):
+        return {
+            "id": self.id,
+            "own_addr": str(self.own_addr) if self.own_addr else None,
+            "name": self.name,
+            "peer_addr": str(self.peer_addr),
+            "peer_is_client": self.peer_is_client,
+            "bonding_data": self.bonding_data.to_dict(),
+        }
+
+    @classmethod
+    def from_dict(cls, data):
+        entry = cls(data["id"])
+        own_addr = data["own_addr"]
+        entry.own_addr = BLEGapAddr.from_string(own_addr) if own_addr else None
+        entry.peer_addr = BLEGapAddr.from_string(data["peer_addr"])
+        entry.peer_is_client = data["peer_is_client"]
+        entry.bonding_data = BondingData.from_dict(data["bonding_data"])
+        return entry
 
 
 class BondDatabase(object):
@@ -40,16 +135,19 @@ class BondDatabase(object):
     def delete_all(self):
         raise NotImplementedError()
 
-    def __iter__(self):
-        """
-        :rtype: list[BondDbEntry]
-        """
+    def find_entry(self, own_address: PeerAddress,
+                   peer_address: PeerAddress,
+                   peer_is_client: bool,
+                   master_id: BLEGapMasterId = None):
+        raise NotImplementedError()
+
+    def __iter__(self) -> typing.Collection[BondDbEntry]:
         raise NotImplementedError()
 
 
 class BondDatabaseLoader(object):
-    def load(self):
-        """
-        :rtype: BondDatabase
-        """
+    def load(self) -> BondDatabase:
+        raise NotImplementedError()
+
+    def save(self, db: BondDatabase):
         raise NotImplementedError()

--- a/blatann/gap/bond_db.py
+++ b/blatann/gap/bond_db.py
@@ -64,8 +64,9 @@ class BondDbEntry(object):
         # Wrong role
         if peer_is_client != self.peer_is_client:
             return False
-        # Entry has own address and doesn't match
-        if self.own_addr is not None and self.own_addr != own_address:
+        # Entry has own address and doesn't match.
+        own_addr = getattr(self, "own_addr", None)
+        if own_addr is not None and own_addr != own_address:
             return False
 
         if self.peer_address_matches_or_resolves(peer_address):
@@ -99,9 +100,12 @@ class BondDbEntry(object):
         return False
 
     def to_dict(self):
+        # When loaded from older pickle formats, own_addr will not exist
+        own_addr = getattr(self, "own_addr", None)
+
         return {
             "id": self.id,
-            "own_addr": str(self.own_addr) if self.own_addr else None,
+            "own_addr": str(own_addr) if own_addr else None,
             "name": self.name,
             "peer_addr": str(self.peer_addr),
             "peer_is_client": self.peer_is_client,

--- a/blatann/gap/bond_db.py
+++ b/blatann/gap/bond_db.py
@@ -65,8 +65,7 @@ class BondDbEntry(object):
         if peer_is_client != self.peer_is_client:
             return False
         # Entry has own address and doesn't match.
-        own_addr = getattr(self, "own_addr", None)
-        if own_addr is not None and own_addr != own_address:
+        if self.own_addr is not None and self.own_addr != own_address:
             return False
 
         if self.peer_address_matches_or_resolves(peer_address):
@@ -100,12 +99,9 @@ class BondDbEntry(object):
         return False
 
     def to_dict(self):
-        # When loaded from older pickle formats, own_addr will not exist
-        own_addr = getattr(self, "own_addr", None)
-
         return {
             "id": self.id,
-            "own_addr": str(own_addr) if own_addr else None,
+            "own_addr": str(self.own_addr) if self.own_addr else None,
             "name": self.name,
             "peer_addr": str(self.peer_addr),
             "peer_is_client": self.peer_is_client,

--- a/blatann/gap/default_bond_db.py
+++ b/blatann/gap/default_bond_db.py
@@ -1,50 +1,150 @@
+from __future__ import annotations
 import os
 import logging
 import pickle
-from typing import List
+import json
+import typing
+from typing import List, Optional
 
 import blatann
 from blatann.gap.bond_db import BondDatabase, BondDbEntry, BondDatabaseLoader
-
+from blatann.gap.gap_types import PeerAddress
+from blatann.nrf.nrf_types import BLEGapMasterId
 
 logger = logging.getLogger(__name__)
 
 
-system_default_db_file = os.path.join(os.path.dirname(blatann.__file__), ".user", "bonding_db.pkl")
-user_default_db_file = os.path.join(os.path.expanduser("~"), ".blatann", "bonding_db.pkl")
+system_default_db_base_filename = os.path.join(os.path.dirname(blatann.__file__), ".user", "bonding_db")
+user_default_db_base_filename = os.path.join(os.path.expanduser("~"), ".blatann", "bonding_db")
+special_bond_db_filemap = {
+    "user": user_default_db_base_filename,
+    "system": system_default_db_base_filename
+}
+
+
+class DatabaseStrategy:
+    @property
+    def file_extension(self) -> str:
+        raise NotImplementedError
+
+    def load(self, filename) -> DefaultBondDatabase:
+        raise NotImplementedError
+
+    def save(self, filename: str, db: DefaultBondDatabase):
+        raise NotImplementedError
+
+
+class JsonDatabaseStrategy(DatabaseStrategy):
+    @property
+    def file_extension(self) -> str:
+        return ".json"
+
+    def load(self, filename) -> DefaultBondDatabase:
+        with open(filename, "r") as f:
+            data = json.load(f)
+        records = [BondDbEntry.from_dict(e) for e in data["records"]]
+        return DefaultBondDatabase(records)
+
+    def save(self, filename: str, db: DefaultBondDatabase):
+        data = {"records": [r.to_dict() for r in db]}
+        with open(filename, "w") as f:
+            json.dump(data, f, indent=2)
+
+
+class PickleDatabaseStrategy(DatabaseStrategy):
+    @property
+    def file_extension(self) -> str:
+        return ".pkl"
+
+    def load(self, filename) -> DefaultBondDatabase:
+        with open(filename, "rb") as f:
+            db = pickle.load(f)
+            return db
+
+    def save(self, filename, db: DefaultBondDatabase):
+        with open(filename, "wb") as f:
+            pickle.dump(db, f)
+
+
+database_strategies = [
+    PickleDatabaseStrategy(),
+    JsonDatabaseStrategy()
+]
+
+database_strategies_by_extension: typing.Dict[str, DatabaseStrategy] = {
+    s.file_extension: s for s in database_strategies
+}
 
 
 # TODO 04.16.2019: Replace pickling with something more secure
 class DefaultBondDatabaseLoader(BondDatabaseLoader):
-    def __init__(self, filename=user_default_db_file):
-        self.filename = filename
+    def __init__(self, filename=user_default_db_base_filename):
+        if filename in special_bond_db_filemap:
+            base_filename = special_bond_db_filemap[filename]
+            self.filename = self.migrate_to_json(base_filename)
+        else:
+            self.filename = filename
+        self.strategy = None
+
+    def _get_strategy(self):
+        if self.strategy is None:
+            file_ext = os.path.splitext(self.filename)[1]
+            if file_ext not in database_strategies_by_extension:
+                raise ValueError(f"Unsupported file type '{file_ext}'. "
+                                 f"Supported extensions: {', '.join(database_strategies_by_extension.keys())}")
+            self.strategy = database_strategies_by_extension[file_ext]
+        return self.strategy
+
+    def migrate_to_json(self, base_filename):
+        pkl_file = base_filename + ".pkl"
+        json_file = base_filename + ".json"
+        # If the pickle file doesn't exist, it's either already been migrated to JSON
+        # or never existed at all. Either way use JSON
+        if not os.path.exists(pkl_file):
+            return json_file
+
+        migration_required = False
+        if os.path.exists(json_file):
+            if os.path.getmtime(pkl_file) > os.path.getmtime(json_file):
+                logger.warning("Both pickle and json bond databases exist, pickle file is newer."
+                               "The existing json bond database will be overwritten")
+                migration_required = True
+        else:
+            migration_required = True
+        # Pickle file exists. If JSON file does not exist, load the db using the pickler,
+        # then save it out using the json
+        if migration_required:
+            migrate_bond_database(pkl_file, json_file)
+        os.remove(pkl_file)
+        return json_file
 
     def _create_dirs(self):
         dirname = os.path.dirname(self.filename)
         if not os.path.exists(dirname):
             os.makedirs(dirname)
 
-    def load(self):
+    def load(self) -> DefaultBondDatabase:
         if not os.path.exists(self.filename):
             return DefaultBondDatabase()
+
+        strategy = self._get_strategy()
         try:
-            with open(self.filename, "rb") as f:
-                db = pickle.load(f)
-                logger.info("Loaded Bond DB '{}'".format(self.filename))
-                return db
+            db = strategy.load(self.filename)
+            return db
         except Exception as e:
             logger.exception("Failed to load Bond DB '{}'".format(self.filename))
             return DefaultBondDatabase()
 
-    def save(self, db):
+    def save(self, db: DefaultBondDatabase):
+        strategy = self._get_strategy()
         self._create_dirs()
-        with open(self.filename, "wb") as f:
-            pickle.dump(db, f)
+        logger.info(f"Saving bond database to {self.filename}")
+        strategy.save(self.filename, db)
 
 
 class DefaultBondDatabase(BondDatabase):
-    def __init__(self):
-        self._records: List[BondDbEntry] = []
+    def __init__(self, records: List[BondDbEntry] = None):
+        self._records = records or []
         self.current_id = 0
 
     def __iter__(self):
@@ -81,3 +181,28 @@ class DefaultBondDatabase(BondDatabase):
 
     def delete_all(self):
         self._records = []
+
+    def find_entry(self, own_address: PeerAddress,
+                   peer_address: PeerAddress,
+                   peer_is_client: bool,
+                   master_id: BLEGapMasterId = None) -> Optional[BondDbEntry]:
+        for record in self._records:
+            if record.matches_peer(own_address, peer_address, peer_is_client, master_id):
+                return record
+
+        return None
+
+
+def migrate_bond_database(from_file: str, to_file: str):
+    from_ext = os.path.splitext(from_file)[1]
+    to_ext = os.path.splitext(to_file)[1]
+    supported_extensions = ", ".join(database_strategies_by_extension.keys())
+    if from_ext not in database_strategies_by_extension:
+        raise ValueError(f"Unsupported file extension '{from_ext}'. Supported extensions: {supported_extensions}")
+    if to_ext not in database_strategies_by_extension:
+        raise ValueError(f"Unsupported file_extension '{to_ext}'. Supported extensions: {supported_extensions}")
+    load_strategy = database_strategies_by_extension[from_ext]
+    save_strategy = database_strategies_by_extension[to_ext]
+    logger.info(f"Migrating Bond DB '{from_file}' to '{to_file}'")
+    db = load_strategy.load(from_file)
+    save_strategy.save(to_file, db)

--- a/blatann/gap/default_bond_db.py
+++ b/blatann/gap/default_bond_db.py
@@ -59,6 +59,11 @@ class PickleDatabaseStrategy(DatabaseStrategy):
     def load(self, filename) -> DefaultBondDatabase:
         with open(filename, "rb") as f:
             db = pickle.load(f)
+            # Check if records are old entries missing own_db. If so, add it in
+            for record in db:
+                if not hasattr(record, "own_addr"):
+                    print("Adding own_addr")
+                    record.own_addr = None
             return db
 
     def save(self, filename, db: DefaultBondDatabase):

--- a/blatann/nrf/nrf_types/smp.py
+++ b/blatann/nrf/nrf_types/smp.py
@@ -167,6 +167,18 @@ class BLEGapMasterId(object):
         ediv = master_id.ediv
         return cls(ediv, bytearray(rand))
 
+    def to_dict(self):
+        return {
+            "ediv": self.ediv,
+            "rand": binascii.hexlify(self.rand).decode("ascii")
+        }
+
+    @classmethod
+    def from_dict(cls, data):
+        ediv = data["ediv"]
+        rand = binascii.unhexlify(data["rand"])
+        return cls(ediv, rand)
+
     def __eq__(self, other):
         if not isinstance(other, BLEGapMasterId):
             return False
@@ -200,6 +212,20 @@ class BLEGapEncryptInfo(object):
         auth = info.auth
         return cls(ltk, lesc, auth)
 
+    def to_dict(self):
+        return {
+            "ltk": binascii.hexlify(self.ltk).decode("ascii"),
+            "lesc": self.lesc,
+            "auth": self.auth
+        }
+
+    @classmethod
+    def from_dict(cls, data):
+        ltk = binascii.unhexlify(data["ltk"])
+        lesc = data["lesc"]
+        auth = data["auth"]
+        return cls(ltk, lesc, auth)
+
     def __repr__(self):
         if not self.ltk:
             return ""
@@ -222,6 +248,18 @@ class BLEGapEncryptKey(object):
     def from_c(cls, key):
         enc_info = BLEGapEncryptInfo.from_c(key.enc_info)
         master_id = BLEGapMasterId.from_c(key.master_id)
+        return cls(enc_info, master_id)
+
+    def to_dict(self):
+        return {
+            "enc_info": self.enc_info.to_dict(),
+            "master_id": self.master_id.to_dict()
+        }
+
+    @classmethod
+    def from_dict(cls, data):
+        enc_info = BLEGapEncryptInfo.from_dict(data["enc_info"])
+        master_id = BLEGapMasterId.from_dict(data["master_id"])
         return cls(enc_info, master_id)
 
     def __repr__(self):
@@ -255,6 +293,18 @@ class BLEGapIdKey(object):
         irk = bytearray(util.uint8_array_to_list(id_key.id_info.irk, cls.KEY_LENGTH))
         addr = BLEGapAddr.from_c(id_key.id_addr_info)
         return cls(irk, addr)
+
+    def to_dict(self):
+        return {
+            "irk": binascii.hexlify(self.irk).decode("ascii"),
+            "peer_addr": str(self.peer_addr) if self.peer_addr is not None else None
+        }
+
+    @classmethod
+    def from_dict(cls, data):
+        irk = binascii.unhexlify(data["irk"])
+        peer_addr = BLEGapAddr.from_string(data["peer_addr"])
+        return cls(irk, peer_addr)
 
     def __repr__(self):
         if not self.irk:
@@ -325,6 +375,15 @@ class BLEGapSignKey(object):
     def from_c(cls, key):
         key_data = bytearray(util.uint8_array_to_list(key.csrk, cls.KEY_LENGTH))
         return cls(key_data)
+
+    def to_dict(self):
+        return {
+            "key": binascii.hexlify(self.key).decode("ascii")
+        }
+
+    @classmethod
+    def from_dict(cls, data):
+        return cls(binascii.unhexlify(data["key"]))
 
     def __repr__(self):
         if not self.key:

--- a/tests/integrated/.gitignore
+++ b/tests/integrated/.gitignore
@@ -1,2 +1,3 @@
 # Bonding database used for integrated tests
 bond_db*.pkl
+bond_db*.json

--- a/tests/integrated/base.py
+++ b/tests/integrated/base.py
@@ -16,7 +16,7 @@ HERE = os.path.dirname(__file__)
 
 BLATANN_QUICK_ENVKEY = "BLATANN_TEST_QUICK"
 BLATANN_DEV_ENVKEY_FORMAT = "BLATANN_DEV_{}"
-BOND_DB_FILE_FMT = os.path.join(HERE, "bond_db{}.pkl")
+BOND_DB_FILE_FMT = os.path.join(HERE, "bond_db{}.json")
 
 
 def _configure_device(dev_number, config, optional=False):


### PR DESCRIPTION
- Adds logic to save/load bond databases in JSON format
  - Both pickle and JSON formats are supported, however JSON is the preferred method going forward
- Adds migration logic to convert existing pickle bond dbs to json
  - the `"user"` and `"system"` special filenames are migrated automatically. Other specified filenames need to be manually migrated using `blatann.default_bond_db.migrate_bond_database(from_file, to_file)`
- Bonding records are now aware of the nRF's device address. In the case that multiple nRF devices are used, it will not match a bond entry for a different dev board/dongle
- Logic for matching a bond entry to a peer's info is moved from the SecurityManager into the BondDbEntry (precursor to #130)