### PR TITLE
#130: Adds support for scanner to resolve peer addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,10 +64,10 @@ Below lists the supported BLE features and ones that are on the roadmap to imple
     - [X] Transmit Power
     - [X] Advertising channel selection
 - [X] SMP
+    - [X] Private resolvable/non-resolvable advertising 
     - [X] Encryption/Authentication process
     - [X] MITM/Passcode pairing support
     - [X] Store bonding info
-      - Currently uses pickle which is not secure
     - [X] Identity resolve
     - [X] Bonding as Peripheral
     - [X] Bonding as Central

--- a/blatann/gap/bond_db.py
+++ b/blatann/gap/bond_db.py
@@ -57,6 +57,9 @@ class BondDbEntry(object):
         self.bonding_data: BondingData = None
         self.name = ""
 
+    def resolved_peer_address(self) -> PeerAddress:
+        return self.bonding_data.peer_id.peer_addr
+
     def matches_peer(self, own_address: PeerAddress,
                      peer_address: PeerAddress,
                      peer_is_client: bool,
@@ -65,7 +68,9 @@ class BondDbEntry(object):
         if peer_is_client != self.peer_is_client:
             return False
         # Entry has own address and doesn't match.
-        if self.own_addr is not None and self.own_addr != own_address:
+        if (self.own_addr is not None and
+                own_address is not None and
+                self.own_addr != own_address):
             return False
 
         if self.peer_address_matches_or_resolves(peer_address):
@@ -94,7 +99,7 @@ class BondDbEntry(object):
             if self.peer_addr == peer_address:
                 return True
         elif smp_crypto.private_address_resolves(peer_address, self.bonding_data.peer_id.irk):
-            logger.info("Resolved Peer address to {}".format(self.peer_addr))
+            logger.debug("Resolved Peer address to {}".format(self.peer_addr))
             return True
         return False
 

--- a/tests/integrated/test_security.py
+++ b/tests/integrated/test_security.py
@@ -68,6 +68,7 @@ class TestSecurity(BlatannTestCase):
             if scan_report.device_name == "BlatannTest":
                 if should_be_bonded:
                     self.assertTrue(scan_report.is_bonded_device)
+                    self.assertIsNotNone(scan_report.resolved_address)
                 return scan_report.peer_address
         return None
 


### PR DESCRIPTION
- Scanner will now check the bond database when it receives a packet if the address resolves to a bonded device
- ScanReport will use the resolved address as a key for the `_scans_by_peer_address` dict

Fixes #130 