### PR TITLE
Added/updated links to compatible nRF52 hardware

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,14 @@ An example shell script to do so can be found [here](./tools/macos_retarget_pc_b
 
 #### Supported Devices/Software
 
-This library has been tested using both the nRF52 Dev Kits, the nRF52840 USB Dongle and the [ABSniffer 528](https://blog.aprbrother.com/product/absniffer-usb-dongle-528) flashed with Connectivity Firmware
+This library has been tested with the following hardware:
+
+- the [nRF52-DK](https://www.nordicsemi.com/Products/Development-hardware/nrf52-dk): a Dev Kit for the nRF52832
+- the [nRF52840-DK](https://www.nordicsemi.com/Products/Development-hardware/nRF52840-DK): a Dev Kit for the nRF52840
+- the [nRF52840-Dongle](https://www.nordicsemi.com/Products/Development-hardware/nrf52840-dongle): a nRF52840 USB Dongle
+- the [ABSniffer-528](https://wiki.aprbrother.com/en/ABSniffer_USB_Dongle_528.html): a nRF52832 USB Dongle
+
+Flashed with specific Connectivity firmware released by Nordic Semiconductor.
 
 **Supported Versions:**
 


### PR DESCRIPTION
Added/updated links to compatible nRF52 hardware.

The link for the ABSniffer 528 blog post wasn't working anymore, so this has been updated to a different resource.

For the Nordic Semiconductor products the original text was clear on the nRF52840-Dongle, but just mentioning _"both the nRF52 Dev Kits"_ wasn't... As the _"Development kits for the nRF52 Series"_ section of the [Nordic Semiconductor BLE Hardware](https://www.nordicsemi.com/Products/Bluetooth-Low-Energy/Development-hardware) page lists three (3) Dev Kits for the nRF52 series. So **_"both"_** wasn't explicit enough.

The table showed that "both Dev Kits" actually refers to the nRF52833-DK and the nRF52840-DK, so this has been made more explicit in this PR with the hardware enumeration providing the names and links.