### PR TITLE
Fixed docstring for a Peripheral method

### DIFF
--- a/blatann/peer.py
+++ b/blatann/peer.py
@@ -643,7 +643,7 @@ class Peripheral(Peer):
         and allows the user to decide how to handle the peripheral's requested connection parameters.
 
         The callback is passed in 2 positional parameters: this ``Peripheral`` object
-        and the desired ``ConnectionParameter``s received in the request.
+        and the desired ``ConnectionParameters`` received in the request.
         The callback should return the desired connection parameters to use, or None to reject the request altogether.
 
         :param handler: The callback to determine which connection parameters to negotiate when an update request


### PR DESCRIPTION
Fixed docstring for Peripheral method `set_conn_param_request_handler` to resolve following WARNING when building docs:

```
$ make all
Running Sphinx v7.2.6
loading pickled environment... done
building [mo]: targets for 0 po files that are out of date
writing output... 
building [html]: targets for 94 source files that are out of date
updating environment: 0 added, 94 changed, 0 removed
reading sources... [100%] blatann.waitables.waitable
/home/mdxs/dev/gh/blatann/blatann/peer.py:docstring of blatann.peer.Peripheral.set_conn_param_request_handler:4: WARNING: Inline literal start-string without end-string.
looking for now-outdated files... none found
pickling environment... done
checking consistency... done
preparing documents... done
copying assets... copying static files... done
copying extra files... done
done
writing output... [100%] index
generating indices... genindex py-modindex done
writing additional pages... search done
dumping search index in English (code: en)... done
dumping object inventory... done
build succeeded, 1 warning.

The HTML pages are in _build/html.
```