### PR TITLE
Updated description/aim of Blatann

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,10 @@
 
 blåtann: Norwegian word for "blue tooth"
 
-The goal of this library is to provide a high-level, object-oriented interface
-for performing bluetooth operations using the Nordic nRF52 through Nordic's `pc-ble-driver-py` library
-and the associated Connectivity firmware.
+Blatann aims to provide a high-level, object-oriented interface for interacting
+with Bluetooth Low Energy (BLE) devices through Python. It operates using
+the Nordic Semiconductor nRF52 through Nordic's ``pc-ble-driver-py`` library
+and the associated Connectivity firmware for the device.
 
 Documentation is available on [ReadTheDocs](https://blatann.readthedocs.io)
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -4,8 +4,9 @@ Blatann
 blåtann: Norwegian word for "blue tooth"
 
 Blatann aims to provide a high-level, object-oriented interface for interacting
-with bluetooth devices through python. It operates using a Nordic nRF52 through Nordic's ``pc-ble-driver-py``
-library and the associated Connectivity firmware for the device.
+with Bluetooth Low Energy (BLE) devices through Python. It operates using
+the Nordic Semiconductor nRF52 through Nordic's ``pc-ble-driver-py`` library
+and the associated Connectivity firmware for the device.
 
 .. toctree::
    :maxdepth: 2


### PR DESCRIPTION
Comparing the README and the ReadTheDocs introduction of Blatann showed some differences in the description (aim/goal) that this PR tries to resolve. Also expanded `bluetooth` to `Bluetooth Low Energy (BLE)` to clarify it is specifically for BLE and not Bluetooth in general (as that could be confused to also include Bluetooth "Classic"). Capitalized `Python` as official name of the language and helping readers to assess for which language this library is intended.