### PR TITLE
NordicUartClient to respect MTU size

### DIFF
--- a/blatann/services/nordic_uart/service.py
+++ b/blatann/services/nordic_uart/service.py
@@ -71,8 +71,8 @@ class NordicUartServer(object):
         return cls(service, max_characteristic_size)
 
 
-class NordicUartClient(object, max_characteristic_size=None):
-    def __init__(self, service):
+class NordicUartClient(object):
+    def __init__(self, service, max_characteristic_size=None):
         """
         :type service: blatann.gatt.gattc.GattcService
         """

--- a/blatann/services/nordic_uart/service.py
+++ b/blatann/services/nordic_uart/service.py
@@ -71,13 +71,16 @@ class NordicUartServer(object):
         return cls(service, max_characteristic_size)
 
 
-class NordicUartClient(object):
+class NordicUartClient(object, max_characteristic_size=None):
     def __init__(self, service):
         """
         :type service: blatann.gatt.gattc.GattcService
         """
         self._service = service
-        self._server_characteristic_size = MTU_SIZE_DEFAULT
+        if max_characteristic_size is None:
+            self._server_characteristic_size = self._service.peer.max_mtu_size - WRITE_BYTE_OVERHEAD
+        else:
+            self._server_characteristic_size = max_characteristic_size
         self._tx_char = self._service.find_characteristic(NORDIC_UART_TX_CHARACTERISTIC_UUID)
         self._rx_char = self._service.find_characteristic(NORDIC_UART_RX_CHARACTERISTIC_UUID)
         self._feature_char = self._service.find_characteristic(NORDIC_UART_FEATURE_CHARACTERISTIC_UUID)


### PR DESCRIPTION
Current NordicUartClient limits the size of packets to MTU_SIZE_DEFAULT, this patch changes that to use the current negotiated mtu size