### PR TITLE
Improved integrated tests with nRF52840-Dongles

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
-pc-ble-driver-py>=0.13
 cryptography
+pc-ble-driver-py>=0.17
+pyserial>=3.5
 pytz


### PR DESCRIPTION
When trying to run the `make run-tests` with 2x nRF52840-Dongle (PCA10056) and 1x the nRF52-DK (PCA10040; a Dev Kit for the nRF52832), the nature of the nRF52840-Dongle to reset with breaking the USB device connection causes the tests to fail in the current code base after some tests:

```
# tests results with 2x PCA10056 and 1x PCA10040 with as-is code base (read: pre-PR)
$ export BLATANN_DEV_1=/dev/ttyACM0
$ export BLATANN_DEV_2=/dev/ttyACM1
$ export BLATANN_DEV_3=/dev/ttyACM2
$ make run-tests
[2023-11-13 17:47:03,519] [MainThread] [blatann.device.clear_bonding_data:220] [INFO]: Clearing out all bonding information
[2023-11-13 17:47:03,520] [MainThread] [blatann.nrf.nrf_driver.wrapper:64] [DEBUG]: [/dev/ttyACM0] open()
[2023-11-13 17:47:04,736] [MainThread] [blatann.nrf.nrf_driver.wrapper:64] [DEBUG]: [/dev/ttyACM0] ble_conn_configure(<blatann.nrf.nrf_types.config.BleConnConfig object at 0x7fdd6ab606a0>,)
[2023-11-13 17:47:04,741] [MainThread] [blatann.nrf.nrf_driver.wrapper:64] [DEBUG]: [/dev/ttyACM0] ble_enable(<blatann.nrf.nrf_types.config.BleEnableConfig object at 0x7fdd6ab62e60>,)
[2023-11-13 17:47:04,749] [MainThread] [blatann.nrf.nrf_driver.wrapper:64] [DEBUG]: [/dev/ttyACM0] ble_gap_device_name_set(b'nRF5x',)

# snipped some of the results ...

[DEBUG]: [/dev/ttyACM0] ble_gap_tx_power_set(0,)
[2023-11-13 17:55:12,671] [MainThread] [blatann.nrf.nrf_driver.wrapper:64] [DEBUG]: [/dev/ttyACM1] ble_gap_tx_power_set(0,)
[2023-11-13 17:55:12,674] [MainThread] [blatann.nrf.nrf_driver.wrapper:64] [DEBUG]: [/dev/ttyACM0] ble_gap_adv_data_set({<Types.flags: 1>: [6], <Types.complete_local_name: 9>: 'Blatann Test'}, {})
[2023-11-13 17:55:12,676] [MainThread] [blatann.nrf.nrf_driver.wrapper:64] [DEBUG]: [/dev/ttyACM0] ble_gap_addr_get()
[2023-11-13 17:55:12,679] [MainThread] [blatann.gap.advertising._start:210] [INFO]: Starting advertising, params: 'BLEGapAdvParams'(type: <BLEGapAdvType.connectable_undirected: 0>, interval: 100ms, timeout: 30s, ch mask: 000), auto-restart: False
[2023-11-13 17:55:12,679] [MainThread] [blatann.nrf.nrf_driver.wrapper:64] [DEBUG]: [/dev/ttyACM0] ble_gap_adv_start('BLEGapAdvParams'(type: <BLEGapAdvType.connectable_undirected: 0>, interval: 100ms, timeout: 30s, ch mask: 000), 1)
[2023-11-13 17:55:12,684] [MainThread] [blatann.nrf.nrf_driver.wrapper:64] [DEBUG]: [/dev/ttyACM1] ble_gap_connect(BLEGapAddr(F2:06:73:60:6A:E3,s),)
[2023-11-13 17:55:12,794] [/dev/ttyACM1_Event] [blatann.device.on_driver_event:35] [DEBUG]: Got NRF Driver event: GapEvtConnected(conn_handle=0, peer_addr=BLEGapAddr(F2:06:73:60:6A:E3,s), role=<BLEGapRoles.central: 2>, conn_params=BLEGapConnParams(interval: [7.5-7.5] ms, timeout: 4000.0 ms, latency: 0))
[2023-11-13 17:55:12,794] [/dev/ttyACM1_Event] [blatann.nrf.nrf_driver.wrapper:64] [DEBUG]: [/dev/ttyACM1] ble_gap_addr_get()
[2023-11-13 17:55:12,795] [/dev/ttyACM0_Event] [blatann.device.on_driver_event:35] [DEBUG]: Got NRF Driver event: GapEvtConnected(conn_handle=1, peer_addr=BLEGapAddr(DA:A4:43:6F:89:6D,s), role=<BLEGapRoles.periph: 1>, conn_params=BLEGapConnParams(interval: [7.5-7.5] ms, timeout: 4000.0 ms, latency: 0))
[2023-11-13 17:55:12,796] [/dev/ttyACM0_Event] [blatann.nrf.nrf_driver.wrapper:64] [DEBUG]: [/dev/ttyACM0] ble_gap_addr_get()
[2023-11-13 17:55:12,800] [MainThread] [blatann.nrf.nrf_driver.wrapper:64] [DEBUG]: [/dev/ttyACM0] ble_gap_rssi_start(1, 5, 3)
[2023-11-13 17:55:12,810] [/dev/ttyACM0_Event] [blatann.device.on_driver_event:35] [DEBUG]: Got NRF Driver event: GapEvtRssiChanged(conn_handle=1, rssi=-18)
[2023-11-13 17:55:12,810] [MainThread] [blatann.nrf.nrf_driver.wrapper:64] [DEBUG]: [/dev/ttyACM1] ble_gap_tx_power_set(-20,)
[2023-11-13 17:55:12,840] [/dev/ttyACM0_Event] [blatann.device.on_driver_event:35] [DEBUG]: Got NRF Driver event: GapEvtRssiChanged(conn_handle=1, rssi=-32)
[2023-11-13 17:55:12,840] [MainThread] [blatann.nrf.nrf_driver.wrapper:64] [DEBUG]: [/dev/ttyACM1] ble_gap_tx_power_set(-8,)
[2023-11-13 17:55:12,870] [/dev/ttyACM0_Event] [blatann.device.on_driver_event:35] [DEBUG]: Got NRF Driver event: GapEvtRssiChanged(conn_handle=1, rssi=-23)
[2023-11-13 17:55:12,870] [MainThread] [blatann.nrf.nrf_driver.wrapper:64] [DEBUG]: [/dev/ttyACM0] ble_gap_privacy_set(BLEGapPrivacyParams(enabled=False, resolvable_addr=True, addr_update_rate_s=900),)
[2023-11-13 17:55:12,872] [MainThread] [blatann.nrf.nrf_driver.wrapper:64] [DEBUG]: [/dev/ttyACM1] ble_gap_disconnect(0, <BLEHci.remote_user_terminated_connection: 19>)
[2023-11-13 17:55:12,886] [/dev/ttyACM1_Event] [blatann.device.on_driver_event:35] [DEBUG]: Got NRF Driver event: GapEvtDisconnected(conn_handle=0, reason=<BLEHci.local_host_terminated_connection: 22>)
[2023-11-13 17:55:12,891] [/dev/ttyACM0_Event] [blatann.device.on_driver_event:35] [DEBUG]: Got NRF Driver event: GapEvtDisconnected(conn_handle=1, reason=<BLEHci.remote_user_terminated_connection: 19>)
ok
[2023-11-13 17:55:12,938] [MainThread] [blatann.nrf.nrf_driver.wrapper:64] [DEBUG]: [/dev/ttyACM0] close()
[2023-11-13 17:55:18,127] [MainThread] [blatann.nrf.nrf_driver.wrapper:64] [DEBUG]: [/dev/ttyACM1] close()
[2023-11-13 17:55:25,258] [MainThread] [blatann.device.clear_bonding_data:220] [INFO]: Clearing out all bonding information
[2023-11-13 17:55:25,259] [MainThread] [blatann.nrf.nrf_driver.wrapper:64] [DEBUG]: [/dev/ttyACM0] open()
ERROR
[2023-11-13 17:55:28,469] [MainThread] [blatann.device.clear_bonding_data:220] [INFO]: Clearing out all bonding information
[2023-11-13 17:55:28,469] [MainThread] [blatann.nrf.nrf_driver.wrapper:64] [DEBUG]: [/dev/ttyACM0] open()
[2023-11-13 17:55:29,686] [MainThread] [blatann.nrf.nrf_driver.wrapper:64] [DEBUG]: [/dev/ttyACM0] ble_conn_configure(<blatann.nrf.nrf_types.config.BleConnConfig object at 0x7fdd5772d270>,)
[2023-11-13 17:55:29,691] [MainThread] [blatann.nrf.nrf_driver.wrapper:64] [DEBUG]: [/dev/ttyACM0] ble_enable(<blatann.nrf.nrf_types.config.BleEnableConfig object at 0x7fdd577121d0>,)
[2023-11-13 17:55:29,699] [MainThread] [blatann.nrf.nrf_driver.wrapper:64] [DEBUG]: [/dev/ttyACM0] ble_gap_device_name_set(b'nRF5x',)
[2023-11-13 17:55:29,701] [MainThread] [blatann.nrf.nrf_driver.wrapper:64] [DEBUG]: [/dev/ttyACM0] ble_gap_appearance_set(<Appearance.unknown: 0>,)
[2023-11-13 17:55:29,703] [MainThread] [blatann.device.clear_bonding_data:220] [INFO]: Clearing out all bonding information
[2023-11-13 17:55:29,704] [MainThread] [blatann.nrf.nrf_driver.wrapper:64] [DEBUG]: [/dev/ttyACM1] open()
ERROR
[2023-11-13 17:55:33,114] [MainThread] [blatann.device.clear_bonding_data:220] [INFO]: Clearing out all bonding information
[2023-11-13 17:55:33,114] [MainThread] [blatann.nrf.nrf_driver.wrapper:64] [DEBUG]: [/dev/ttyACM0] open()
ERROR
[2023-11-13 17:55:36,521] [MainThread] [blatann.device.clear_bonding_data:220] [INFO]: Clearing out all bonding information
[2023-11-13 17:55:36,521] [MainThread] [blatann.nrf.nrf_driver.wrapper:64] [DEBUG]: [/dev/ttyACM0] open()
[2023-11-13 17:55:37,734] [MainThread] [blatann.nrf.nrf_driver.wrapper:64] [DEBUG]: [/dev/ttyACM0] ble_conn_configure(<blatann.nrf.nrf_types.config.BleConnConfig object at 0x7fdd578d6350>,)
ERROR

======================================================================
ERROR: setUpClass (integrated.test_gatt.TestGatt)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/mdxs/dev/gh/blatann/tests/integrated/test_gatt.py", line 74, in setUpClass
    super(TestGatt, cls).setUpClass()
  File "/home/mdxs/dev/gh/blatann/tests/integrated/base.py", line 63, in setUpClass
    cls.dev1.open(True)
  File "/home/mdxs/dev/gh/blatann/blatann/device.py", line 198, in open
    self.ble_driver.open()
  File "/home/mdxs/dev/gh/blatann/blatann/nrf/nrf_driver.py", line 80, in wrapper
    raise NordicSemiException('Failed to {}. {}'.format(wrapped.__name__, err_string), err_code)
pc_ble_driver_py.exceptions.NordicSemiException: Failed to open. Error code: NrfError.rpc_h5_transport_state

======================================================================
ERROR: setUpClass (integrated.test_gatt_writes.TestGattWrites)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/mdxs/dev/gh/blatann/tests/integrated/test_gatt_writes.py", line 44, in setUpClass
    super(TestGattWrites, cls).setUpClass()
  File "/home/mdxs/dev/gh/blatann/tests/integrated/base.py", line 64, in setUpClass
    cls.dev2.open(True)
  File "/home/mdxs/dev/gh/blatann/blatann/device.py", line 198, in open
    self.ble_driver.open()
  File "/home/mdxs/dev/gh/blatann/blatann/nrf/nrf_driver.py", line 80, in wrapper
    raise NordicSemiException('Failed to {}. {}'.format(wrapped.__name__, err_string), err_code)
pc_ble_driver_py.exceptions.NordicSemiException: Failed to open. Error code: NrfError.timeout

======================================================================
ERROR: setUpClass (integrated.test_scanner.TestScanner)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/mdxs/dev/gh/blatann/tests/integrated/base.py", line 63, in setUpClass
    cls.dev1.open(True)
  File "/home/mdxs/dev/gh/blatann/blatann/device.py", line 198, in open
    self.ble_driver.open()
  File "/home/mdxs/dev/gh/blatann/blatann/nrf/nrf_driver.py", line 80, in wrapper
    raise NordicSemiException('Failed to {}. {}'.format(wrapped.__name__, err_string), err_code)
pc_ble_driver_py.exceptions.NordicSemiException: Failed to open. Error code: NrfError.timeout

======================================================================
ERROR: setUpClass (integrated.test_security.TestSecurity)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/mdxs/dev/gh/blatann/tests/integrated/test_security.py", line 27, in setUpClass
    super(TestSecurity, cls).setUpClass()
  File "/home/mdxs/dev/gh/blatann/tests/integrated/base.py", line 63, in setUpClass
    cls.dev1.open(True)
  File "/home/mdxs/dev/gh/blatann/blatann/device.py", line 200, in open
    self.ble_driver.ble_conn_configure(self._default_conn_config)
  File "/home/mdxs/dev/gh/blatann/blatann/nrf/nrf_driver.py", line 80, in wrapper
    raise NordicSemiException('Failed to {}. {}'.format(wrapped.__name__, err_string), err_code)
pc_ble_driver_py.exceptions.NordicSemiException: Failed to ble_conn_configure. Error code: NrfError.rpc_no_response

----------------------------------------------------------------------
Ran 16 tests in 514.829s

FAILED (errors=4)
make: *** [Makefile:48: run-tests] Error 1
```

One of the errors seen is the `NrfError.rpc_h5_transport_state`, which was also reported in #75 and #103 - in which I wrote about a workaround that worked for me on Linux (I've not yet tested it on Windows).

Using that approach in this PR improved the number of tests performed with `make run-tests` on Linux, though it doesn't seem to complete all the tests either:

```
# tests results with 2x PCA10056 and 1x PCA10040 with this PR applied to the code base

# snipped some of the results ...
[2023-11-13 18:57:57,304] [MainThread] [blatann.gap.smp.pair:300] [INFO]: Re-establishing encryption with peer using LTKs
[2023-11-13 18:57:57,304] [MainThread] [blatann.nrf.nrf_driver.wrapper:64] [DEBUG]: [/dev/ttyACM1] ble_gap_encrypt(0, BLEGapMasterId(e: 0, r: b'0000000000000000'), Encrypt(ltk: b'154fbf2923e23baf68bb630da29f4f25', lesc: 1, auth: 0))
[2023-11-13 18:57:57,501] [/dev/ttyACM0_Event] [blatann.device.on_driver_event:35] [DEBUG]: Got NRF Driver event: GapEvtSecInfoRequest(conn_handle=1, peer_addr=BLEGapAddr(F2:06:73:60:6A:E3,s), master_id=BLEGapMasterId(e: 0, r: b'0000000000000000'), enc=1, id=0, sign=0)
[2023-11-13 18:57:57,502] [/dev/ttyACM0_Event] [blatann.nrf.nrf_driver.wrapper:64] [DEBUG]: [/dev/ttyACM0] ble_gap_sec_info_reply(1, Encrypt(ltk: b'154fbf2923e23baf68bb630da29f4f25', lesc: 1, auth: 0), irk: b3ca68cc2abde80368d0f81973a7b080, peer: F2:06:73:60:6A:E3,s, None)
[2023-11-13 18:57:58,000] [/dev/ttyACM1_Event] [blatann.device.on_driver_event:35] [DEBUG]: Got NRF Driver event: GapEvtConnSecUpdate(conn_handle=0, sec_mode=1, sec_level=2, encr_key_size=16)
[2023-11-13 18:57:58,001] [/dev/ttyACM0_Event] [blatann.device.on_driver_event:35] [DEBUG]: Got NRF Driver event: GapEvtConnSecUpdate(conn_handle=1, sec_mode=1, sec_level=2, encr_key_size=16)
[2023-11-13 18:57:58,502] [MainThread] [blatann.nrf.nrf_driver.wrapper:64] [DEBUG]: [/dev/ttyACM1] ble_gap_disconnect(0, <BLEHci.remote_user_terminated_connection: 19>)
[2023-11-13 18:57:58,700] [/dev/ttyACM1_Event] [blatann.device.on_driver_event:35] [DEBUG]: Got NRF Driver event: GapEvtDisconnected(conn_handle=0, reason=<BLEHci.local_host_terminated_connection: 22>)
[2023-11-13 18:57:58,701] [/dev/ttyACM0_Event] [blatann.device.on_driver_event:35] [DEBUG]: Got NRF Driver event: GapEvtDisconnected(conn_handle=1, reason=<BLEHci.remote_user_terminated_connection: 19>)
ok
[2023-11-13 18:57:59,935] [MainThread] [blatann.nrf.nrf_driver.wrapper:64] [DEBUG]: [/dev/ttyACM0] close()
[2023-11-13 18:58:00,038] [MainThread] [blatann.nrf.nrf_driver.wrapper:64] [DEBUG]: [/dev/ttyACM1] close()

======================================================================
ERROR: test_long_reads_writes (integrated.test_gatt.TestGatt)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/mdxs/dev/gh/blatann/tests/integrated/test_gatt.py", line 264, in test_long_reads_writes
    self.periph_conn.large_char.set_value(value)
  File "/home/mdxs/dev/gh/blatann/blatann/gatt/gatts.py", line 168, in set_value
    self._value_attr.set_value(value)
  File "/home/mdxs/dev/gh/blatann/blatann/gatt/gatts_attribute.py", line 114, in set_value
    self._ble_device.ble_driver.ble_gatts_value_set(self._peer.conn_handle, self._handle, v)
  File "/home/mdxs/dev/gh/blatann/blatann/nrf/nrf_driver.py", line 80, in wrapper
    raise NordicSemiException('Failed to {}. {}'.format(wrapped.__name__, err_string), err_code)
pc_ble_driver_py.exceptions.NordicSemiException: Failed to ble_gatts_value_set. Error code: NrfError.rpc_no_response

----------------------------------------------------------------------
Ran 37 tests in 810.756s

FAILED (errors=1)
make: *** [Makefile:48: run-tests] Error 1
```

Right now, I don't know what caused this particular error. Perhaps it is a callback with something after the devices have been closed. But I honestly didn't look into this too much at this point...

So this PR is improving the ability to test Blatann when using the nRF52840-Dongle (one or more), but it is clearly incomplete and thus I marked it [Experimental]. I've also added PySerial to the requirements and updated the `pc-ble-driver-py` requirement to use the latest v0.17 to make it explicit under which conditions I've started the tests.