### PR TITLE
Pass class instance for lesc private key generation

### DIFF
--- a/blatann/gap/smp_crypto.py
+++ b/blatann/gap/smp_crypto.py
@@ -78,7 +78,7 @@ def lesc_generate_private_key() -> ec.EllipticCurvePrivateKey:
 
     :return: The generated private key
     """
-    return ec.generate_private_key(_lesc_curve, _backend)
+    return ec.generate_private_key(_lesc_curve(), _backend)
 
 
 def lesc_compute_dh_key(private_key: ec.EllipticCurvePrivateKey,


### PR DESCRIPTION
Passing the class directly throws a deprecation warning from cryptography. 

> CryptographyDeprecationWarning: Curve argument: Curve argument must be an instance of an EllipticCurve class. Did you pass a class by mistake? This will be an exception in a future version of cryptography.

See the documentation for Cryptography
https://cryptography.io/en/43.0.0/hazmat/primitives/asymmetric/ec.html